### PR TITLE
💄 Add : SnSPost 컴포넌트 구현

### DIFF
--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { FollowToggleBtn } from '../button/Button.jsx'
-import { ProfileIconM } from '../profileIcon/ProfileIcon.jsx'
+import { ProfileIconS } from '../profileIcon/ProfileIcon.jsx'
 import { TextWrapper, UserId, UserName, Wrapper } from './userStyle.js'
 
 
 export function User() {
   return (
     <Wrapper>
-      <ProfileIconM />
+      <ProfileIconS />
       <TextWrapper>
         <UserName>코랑이</UserName>
         <UserId>@coding_arang</UserId>

--- a/src/template/snsPost/SnsPost.jsx
+++ b/src/template/snsPost/SnsPost.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { User } from '../../components/user/User.jsx'
+import { IconWrap, PostImg, PostText, WrapperArticle, WrapSection, IconImg, DateText } from './snsPostStyle'
+import image from '../../assets/basic-profile.svg'
+import heartIcon from '../../assets/icon-heart.svg'
+import messageIcon from '../../assets/icon-message.svg'
+
+function SnsPost() {
+  return (
+    <article>
+      <WrapperArticle>
+        <User />
+        <WrapSection>
+          <PostText>우리 아랑이가 드디어 코딩을 할 줄 알아요..!! 우리 애기 천재💗🐿️</PostText>
+          <PostImg src={image} />
+          <IconWrap>
+            <IconImg src={heartIcon} />38
+            <IconImg src={messageIcon} />55
+          </IconWrap>
+          <DateText>2022년 07월 01일</DateText>
+        </WrapSection>
+
+      </WrapperArticle>
+
+    </article>
+  )
+}
+
+export default SnsPost

--- a/src/template/snsPost/snsPostStyle.js
+++ b/src/template/snsPost/snsPostStyle.js
@@ -28,7 +28,7 @@ box-sizing: border-box;
 export const IconWrap = styled.div`
 text-align: left;
 display: inline-block;
-margin-bottom: 10px;
+margin: 14px 0;
 `
 
 export const IconImg = styled.img`

--- a/src/template/snsPost/snsPostStyle.js
+++ b/src/template/snsPost/snsPostStyle.js
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+
+export const WrapperArticle = styled.article`
+width: 100%;
+`
+
+export const WrapSection = styled.section`
+padding-left: 45px;
+`
+
+export const PostText = styled.p`
+font-size: 14px;
+line-height: 17px;
+text-align: left;
+word-break: keep-all;
+white-space: pre-wrap;
+margin: 14px 0;
+`
+
+export const PostImg = styled.img`
+width: 100%;
+height: 60vw;
+border: 1px solid #DBDBDB;
+border-radius: 10px;
+box-sizing: border-box;
+`
+
+export const IconWrap = styled.div`
+text-align: left;
+display: inline-block;
+margin-bottom: 10px;
+`
+
+export const IconImg = styled.img`
+background-color: none;
+width: 20px;
+height: 20px;
+border: transparent;
+vertical-align: -5px;
+margin: 0 6px 0px 15px;
+:first-child{
+  margin-left: 0;
+}
+`
+export const DateText = styled.p`
+color: #767676;
+font-size: 10px;
+line-height: 12px;
+text-align: left;
+`


### PR DESCRIPTION
## SnS페이지에서 사용되는 Post 컴포넌트 구현
- 반응형으로 제작하여 화면 넓이에 비례하여 이미지 높이가 조정됩니다. vw사용
- postText의 경우 word-break : keep-all 속성을 사용하여 단어별로 글자가 끊겨 사용자가 더 보기 편하도록 구현 하였습니다.
- postText 또한 화면 넓이에 비례하여 넓이가 조정됩니다. 
- PostText - img, Icon - Img 사이 마진 간격 조정 (추가 커밋)


![image](https://user-images.githubusercontent.com/54096506/177937042-36fb3342-f5d8-4128-b682-9f035f9b87fd.png)
( 예시 이미지는 글로벌 스타일이 적용되지 않은 이미지로 마진간격이 약간 다를 수 있습니다.)

close #54