### PR TITLE
:lipstick: Style : 404 페이지 UI 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import GlobalStyles from './style/globalStyle';
 import { Route, Router, Routes } from 'react-router-dom'
-import Homepage from './pages/Homepage';
+import HomePage from './pages/HomePage';
 import Main from './template/main/Main';
 import InitPage from './pages/InitPage';
 import Login from './template/login/Login'
@@ -19,7 +19,7 @@ function App() {
         {/* <Route path='/main' element={<Main/>}> </Route> */}
         <Route path='/login' element={<Login />}></Route>
         <Route path='/join' element={<SignUpMainPage />}> </Route>
-        <Route path='/homepage' element={<Homepage/>}></Route>
+        <Route path='/homepage' element={<HomePage/>}></Route>
         
       </Routes>
       <AnimatePresence />

--- a/src/components/followCompo/FollowCompo.jsx
+++ b/src/components/followCompo/FollowCompo.jsx
@@ -1,16 +1,30 @@
 import React from 'react'
-import {FollowCompoWrapper,DefaultImg,DefaultTxt} from './followCompoStyle'
+import { FollowCompoWrapper, DefaultImg, DefaultTxt } from './followCompoStyle'
 import grayLogo from '../../assets/gray-logo.svg'
+import logo404 from '../../assets/404-logo.svg'
 import { MiddleBtn } from '../../components/button/Button'
 
-export default function FollowCompo(props) {
+export function FollowCompo(props) {
   return (
     <FollowCompoWrapper>
-      <img src={grayLogo}/>
-      <DefaultTxt> 
+      <img src={grayLogo} />
+      <DefaultTxt>
         {props.textDefault}
       </DefaultTxt>
-      <MiddleBtn textBtn={props.textBtn}/>
+      <MiddleBtn textBtn={props.textBtn} />
     </FollowCompoWrapper>
   )
 }
+
+export function NotFoundCompo() {
+  return (
+    <FollowCompoWrapper>
+      <img src={logo404} />
+      <DefaultTxt>
+        페이지를 찾을 수 없습니다. :(
+      </DefaultTxt>
+      <MiddleBtn textBtn={'이전 페이지'} />
+    </FollowCompoWrapper>
+  )
+}
+

--- a/src/pages/FeedPage.jsx
+++ b/src/pages/FeedPage.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {NavSearch} from '../components/navBack/NavBack'
-import {AllWrap} from '../style/commonStyle'
-import FollowCompo from '../components/followCompo/FollowCompo'
-import {AddBtn} from '../components/iconButton/IconButton'
+import { NavSearch } from '../components/navBack/NavBack'
+import { AllWrap } from '../style/commonStyle'
+import { FollowCompo } from '../components/followCompo/FollowCompo'
+import { AddBtn } from '../components/iconButton/IconButton'
 import TabMenu from '../components/tabMenu/TabMenu'
 
-export default function Homepage() {
-  const textBtn ="검색하기"
+export default function FeedPage() {
+  const textBtn = "검색하기"
   const textDefault = "유저를 검색해 팔로우 해보세요!"
   return (
     <AllWrap>
@@ -14,9 +14,9 @@ export default function Homepage() {
         <NavSearch text={"Pet Story"} />
       </header>
       <main>
-        <FollowCompo textBtn={textBtn} textDefault={textDefault}/>
-        <AddBtn/>
-        <TabMenu/>
+        <FollowCompo textBtn={textBtn} textDefault={textDefault} />
+        <AddBtn />
+        <TabMenu />
       </main>
     </AllWrap>
   )

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {NavSearch} from '../components/navBack/NavBack'
-import {AllWrap} from '../style/commonStyle'
-import FollowCompo from '../components/followCompo/FollowCompo'
-import {AddBtn} from '../components/iconButton/IconButton'
+import { NavSearch } from '../components/navBack/NavBack'
+import { AllWrap } from '../style/commonStyle'
+import { FollowCompo } from '../components/followCompo/FollowCompo'
+import { AddBtn } from '../components/iconButton/IconButton'
 import TabMenu from '../components/tabMenu/TabMenu'
 
-export default function Homepage() {
-  const textBtn ="친구 구하기"
+export default function HomePage() {
+  const textBtn = "친구 구하기"
   const textDefault = "함께 놀 친구들을 찾아보세요! :)"
   return (
     <AllWrap>
@@ -14,9 +14,9 @@ export default function Homepage() {
         <NavSearch text={"친구구해요"} />
       </header>
       <main>
-        <FollowCompo textBtn={textBtn} textDefault={textDefault}/>
-        <AddBtn/>
-        <TabMenu/>
+        <FollowCompo textBtn={textBtn} textDefault={textDefault} />
+        <AddBtn />
+        <TabMenu />
       </main>
     </AllWrap>
   )

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { AllWrap } from '../style/commonStyle'
+import { NotFoundCompo } from '../components/followCompo/FollowCompo'
+
+export default function NotFound() {
+  return (
+    <AllWrap>
+      <NotFoundCompo />
+    </AllWrap>
+  )
+}


### PR DESCRIPTION
* 404 페이지 UI를 위한 NotFoundCompo 컴포넌트 추가
* 컴포넌트를 이용하여 404 페이지 UI 구현 완료
* NotFoundCompo 컴포넌트를 추가함으로서 FollowCompo의 default 제거
* 관련된 파일(HomePage.jsx / FeedPage.jsx / App.js)에서의 오타와 띄어쓰기 수정


close #99 