### PR TITLE
Feat/게시글렌더링

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,27 +1,37 @@
 import React from 'react'
 import { NavSearch } from '../components/navBack/NavBack'
 import { AllWrap } from '../style/commonStyle'
-import { FollowCompo } from '../components/followCompo/FollowCompo'
-import { AddBtn } from '../components/iconButton/IconButton'
 import TabMenu from '../components/tabMenu/TabMenu'
-import { Link } from 'react-router-dom'
+import { useSelector,useDispatch} from 'react-redux'
+import { useEffect } from 'react'
+import { selectAllPosts,AxiosPetInfo,getPostStatus } from '../reducers/getPetInfoSlice'
+import DefaultFeed from '../template/walkingFeed/DefaultFeed'
+import WalkingFeed from '../template/walkingFeed/WalkingFeed'
 
 export default function HomePage() {
-  const textBtn = "펫 등록하기"
-  const textDefault = "함께 놀 친구들을 찾아보세요! :)"
-  const url = '/post'
-  return (
+
+  const dispatch = useDispatch();
+  const postsStatus = useSelector(getPostStatus);
+  const URL = "https://mandarin.api.weniv.co.kr";
+  const userInfo = JSON.parse(localStorage.getItem("userinfo")).user
+  const accountname = userInfo.accountname;
+  const loginReqPath = `/product/${accountname}/?limit=30`; //내게시글
+  // const loginReqPath = `/product/?limit=100`;  // 전체게시글 100개
+  const posts = useSelector(selectAllPosts).product;
+  useEffect(()=>{
+    if(postsStatus ==='idle'){
+      dispatch(AxiosPetInfo(URL+loginReqPath))
+    }
+  },[dispatch])
+
+  return (          
     <AllWrap>
       <header>
         <NavSearch text={"산책 피드"} />
       </header>
-      <main>
-        <FollowCompo url={url} textBtn={textBtn} textDefault={textDefault} />
-        <Link to={url}>
-          <AddBtn />
-        </Link>
-        <TabMenu />
-      </main>
+      {(postsStatus==='idle'&&posts?.length===0) ?<DefaultFeed/>:<WalkingFeed/> }
+      <TabMenu />
     </AllWrap>
+              
   )
 }

--- a/src/style/globalStyle.js
+++ b/src/style/globalStyle.js
@@ -30,7 +30,7 @@ footer, header, hgroup, menu, nav, section {
 body {
 	line-height: 1;
 }
-ol, ul {
+ol, ul ,li{
 	list-style: none;
 }
 blockquote, q {

--- a/src/template/post/HomePost.jsx
+++ b/src/template/post/HomePost.jsx
@@ -3,26 +3,12 @@ import { ContentTxt, DateTxt, PetImg, PetInfoTxt, PostStyle, TitleTxt, TxtBox } 
 import { UserChat } from '../../components/user/User'
 import { selectAllPosts ,getPostStatus,AxiosPetInfo} from '../../reducers/getPetInfoSlice'
 import { useDispatch, useSelector } from 'react-redux';
-import { useEffect } from 'react'
-
 
 export default function HomePost() {
   const dispatch = useDispatch();
   const posts = useSelector(selectAllPosts).product;
   const postsStatus = useSelector(getPostStatus);
-  console.log(posts);
-  
-  const URL = "https://mandarin.api.weniv.co.kr";
-  const userInfo = JSON.parse(localStorage.getItem("userinfo")).user
-  const accountname = userInfo.accountname;
-  const loginReqPath = `/product/${accountname}/?limit=30`; //내게시글
-  // const loginReqPath = `/product/?limit=100`;  // 전체게시글 100개
-
-  useEffect(()=>{
-    if(postsStatus ==='idle'){
-      dispatch(AxiosPetInfo(URL+loginReqPath))
-    }
-  },[dispatch])
+  console.log("템플릿",posts);
 
   return ( 
     <>

--- a/src/template/post/HomePost.jsx
+++ b/src/template/post/HomePost.jsx
@@ -1,20 +1,44 @@
 import React from 'react'
 import { ContentTxt, DateTxt, PetImg, PetInfoTxt, PostStyle, TitleTxt, TxtBox } from './homePostStyle'
-import petImg from '../../assets/pet-image.jpg'
 import { UserChat } from '../../components/user/User'
+import { selectAllPosts ,getPostStatus,AxiosPetInfo} from '../../reducers/getPetInfoSlice'
+import { useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react'
 
 
-export default function HomePost(props) {
-  console.log("props",props);
-  return (
-    <PostStyle>
-      <UserChat></UserChat>
-      <PetImg src={petImg}></PetImg>
-      <TxtBox>
-        <TitleTxt>{props.title}시흥쪽 산책 하실분 구합니다.</TitleTxt>
-      </TxtBox>
-      <ContentTxt>{props.content} 다람쥐/2세/수컷/아랑이 내일 시흥쪽에서 같이 산책하실분~</ContentTxt>
-      <DateTxt>{props.date}2020년 10월 21일</DateTxt>
-    </PostStyle>
+export default function HomePost() {
+  const dispatch = useDispatch();
+  const posts = useSelector(selectAllPosts).product;
+  const postsStatus = useSelector(getPostStatus);
+  console.log(posts);
+  
+  const URL = "https://mandarin.api.weniv.co.kr";
+  const userInfo = JSON.parse(localStorage.getItem("userinfo")).user
+  const accountname = userInfo.accountname;
+  const loginReqPath = `/product/${accountname}/?limit=30`; //내게시글
+  // const loginReqPath = `/product/?limit=100`;  // 전체게시글 100개
+
+  useEffect(()=>{
+    if(postsStatus ==='idle'){
+      dispatch(AxiosPetInfo(URL+loginReqPath))
+    }
+  },[dispatch])
+
+  return ( 
+    <>
+      {posts && posts.map((post)=>{
+        return(   
+          <PostStyle key={post.id}>
+            <UserChat/>
+            <PetImg src={"https://mandarin.api.weniv.co.kr/"+post.itemImage}></PetImg>
+            <TxtBox>
+              <TitleTxt>{post.itemName}</TitleTxt>
+            </TxtBox>
+            <ContentTxt>{post.link}</ContentTxt>
+            <DateTxt>{post.updatedAt}</DateTxt>
+          </PostStyle>
+        )
+      })}
+    </>
   )
 }

--- a/src/template/post/homePostStyle.js
+++ b/src/template/post/homePostStyle.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 
-export const PostStyle = styled.div`
+export const PostStyle = styled.li`
   width: 390px;
   margin: 0 auto;
   padding: 10px 34px;

--- a/src/template/walkingFeed/DefaultFeed.jsx
+++ b/src/template/walkingFeed/DefaultFeed.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { FollowCompo } from '../../components/followCompo/FollowCompo'
+import { AddBtn } from '../../components/iconButton/IconButton'
+import { Link } from 'react-router-dom'
+
+export default function DefaultFeed() {
+  const textBtn = "펫 등록하기"
+  const textDefault = "함께 놀 친구들을 찾아보세요! :)"
+  const url = '/post'
+  return (
+    <main>
+      <FollowCompo url={url} textBtn={textBtn} textDefault={textDefault} />
+      <Link to={url}>
+        <AddBtn/>
+      </Link>
+    </main>
+  )
+}

--- a/src/template/walkingFeed/WalkingFeed.jsx
+++ b/src/template/walkingFeed/WalkingFeed.jsx
@@ -1,30 +1,7 @@
 import React from 'react'
 import HomePost  from '../post/HomePost'
-import axios from 'axios'
-import { createSelector } from '@reduxjs/toolkit'; 
-import { selectAllPosts ,getPostsError ,getPostStatus ,AxiosPetInfo,petInfo} from '../../reducers/getPetInfoSlice';
-import { useDispatch, useSelector } from 'react-redux';
-import { useEffect } from 'react';
-
 
 export default function WalkingFeed() {
-
-  const dispatch = useDispatch();
-  const posts = useSelector(selectAllPosts);
-  const postsStatus = useSelector(getPostStatus);
-  const error = useSelector( (state) => state.getPetInfo.error);
-
-  const URL = "https://mandarin.api.weniv.co.kr";
-  const userInfo = JSON.parse(localStorage.getItem("userinfo")).user
-  const accountname = userInfo.accountname;
-  const loginReqPath = `/product/${accountname}`;
-
-  useEffect(()=>{
-    if(postsStatus ==='idle'){
-      dispatch(AxiosPetInfo(URL+loginReqPath))
-    }
-  },[dispatch])
-
   return (
     <main>
       <HomePost />


### PR DESCRIPTION
**1commit**
- `li`에 reset css적용 , 게시글 태그 `li`로 변경

**2commit**
- RTK와 thunk를 사용하여 axios요청 후 , 값을 받아와 렌더링 까지 성공

**3commit**
- Homepage의 글이없을때 UI와 있을때 UI를 templete으로 빼고 (`DefaultFeed.jsx` , `WalkingFeed.jsx`) ,  공통 컴포넌트 (nav와 tab)을 page에서  마지막에 조건부렌더링.


**issue**
게시글이 등록되고 나서 한번 새로고침을 눌러야 게시글이 보입니다.
UI를 랜더링 후에 dispatch가 실행되어 그런것 같아서  요부분 따로 브랜치 파서 수정하겠습니다. 
