### PR TITLE
Feat/채팅룸페이지UI

### DIFF
--- a/src/components/navBack/navBackStyle.js
+++ b/src/components/navBack/navBackStyle.js
@@ -11,7 +11,6 @@ position: fixed;
 top: 0;
 background:white;
 display:flex;
-justify-content: space-between;
 z-index:10;
 `
 
@@ -26,7 +25,8 @@ export const NavTxt = styled.h1`
   padding:5px;
   font-size:18px;
   line-height:20px;
-  display:inline-block; 
+  display:inline-block;
+  margin-right: auto;
 `
 export const FloatR = styled.div`
   overflow:hidden;

--- a/src/components/speechBubble/SpeechBubble.jsx
+++ b/src/components/speechBubble/SpeechBubble.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { AllWrap } from '../../style/commonStyle'
+import { ProfileIconS } from '../profileIcon/ProfileIcon'
+import { LeftSpeechBubbleWrapper, RightSpeechBubbleWrapper, RightChat, LeftChat, ChatTime } from './speechBubbleStyle'
+
+export default function LeftSpeechBubble() {
+  return (
+    <LeftSpeechBubbleWrapper>
+      <ProfileIconS></ProfileIconS>
+      <LeftChat>
+        아랑이랑 산책하고 싶어서 게시글 시간보고 연락드려요~ 6/28 3시 가능하신가요?
+      </LeftChat>
+      <ChatTime>12:39</ChatTime>
+    </LeftSpeechBubbleWrapper>
+  )
+}
+
+export function RightSpeechBubble() {
+  return (
+    <RightSpeechBubbleWrapper>
+      <ProfileIconS></ProfileIconS>
+      <RightChat>
+        하고있는데요.
+      </RightChat>
+      <ChatTime>12:50</ChatTime>
+    </RightSpeechBubbleWrapper>
+  )
+}

--- a/src/components/speechBubble/SpeechBubble.jsx
+++ b/src/components/speechBubble/SpeechBubble.jsx
@@ -1,28 +1,26 @@
 import React from 'react'
 import { AllWrap } from '../../style/commonStyle'
 import { ProfileIconS } from '../profileIcon/ProfileIcon'
-import { LeftSpeechBubbleWrapper, RightSpeechBubbleWrapper, RightChat, LeftChat, ChatTime } from './speechBubbleStyle'
+import { LeftSpeechBubbleWrapper, RightSpeechBubbleWrapper, RightChat, LeftChat, ChatTime, ChatImage } from './speechBubbleStyle'
 import profileIcon from '../../assets/basic-profile.svg'
 
-export default function LeftSpeechBubble() {
+export function LeftSpeechBubble({ chat, img, time }) {
   return (
     <LeftSpeechBubbleWrapper>
       <ProfileIconS img={profileIcon}></ProfileIconS>
-      <LeftChat>
-        아랑이랑 산책하고 싶어서 게시글 시간보고 연락드려요~ 6/28 3시 가능하신가요?
-      </LeftChat>
-      <ChatTime>12:39</ChatTime>
+      <LeftChat>{chat}</LeftChat>
+      <ChatImage src={img}></ChatImage>
+      <ChatTime>{time}</ChatTime>
     </LeftSpeechBubbleWrapper>
   )
 }
 
-export function RightSpeechBubble() {
+export function RightSpeechBubble({ chat, img, time }) {
   return (
     <RightSpeechBubbleWrapper>
-      <RightChat>
-        하고있는데요.
-      </RightChat>
-      <ChatTime>12:50</ChatTime>
+      <RightChat>{chat}</RightChat>
+      <ChatImage src={img}></ChatImage>
+      <ChatTime>{time}</ChatTime>
     </RightSpeechBubbleWrapper>
   )
 }

--- a/src/components/speechBubble/SpeechBubble.jsx
+++ b/src/components/speechBubble/SpeechBubble.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { AllWrap } from '../../style/commonStyle'
 import { ProfileIconS } from '../profileIcon/ProfileIcon'
 import { LeftSpeechBubbleWrapper, RightSpeechBubbleWrapper, RightChat, LeftChat, ChatTime } from './speechBubbleStyle'
+import profileIcon from '../../assets/basic-profile.svg'
 
 export default function LeftSpeechBubble() {
   return (
     <LeftSpeechBubbleWrapper>
-      <ProfileIconS></ProfileIconS>
+      <ProfileIconS img={profileIcon}></ProfileIconS>
       <LeftChat>
         아랑이랑 산책하고 싶어서 게시글 시간보고 연락드려요~ 6/28 3시 가능하신가요?
       </LeftChat>
@@ -18,7 +19,6 @@ export default function LeftSpeechBubble() {
 export function RightSpeechBubble() {
   return (
     <RightSpeechBubbleWrapper>
-      <ProfileIconS></ProfileIconS>
       <RightChat>
         하고있는데요.
       </RightChat>

--- a/src/components/speechBubble/speechBubbleStyle.js
+++ b/src/components/speechBubble/speechBubbleStyle.js
@@ -1,13 +1,16 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export const LeftSpeechBubbleWrapper = styled.div`
   display: flex;
   padding: 0 16px;
-  margin: 10px 0;
   gap: 6px;
 
-  :first-of-type{
-    margin-top: 48px;
+  :first-of-type {
+    margin-top: auto;
+  }
+
+  :last-of-type {
+    margin-bottom: 80px;
   }
 `
 
@@ -16,15 +19,20 @@ export const RightSpeechBubbleWrapper = styled(LeftSpeechBubbleWrapper)`
 `
 
 export const LeftChat = styled.span`
-  max-width: 55%;
-  padding: 12px;
-  margin-left: 6px;
-  font-size: 14px;
-  line-height: 17px;
-  border: 1px solid #C4C4C4;
-  border-radius: 0px 10px 10px 10px;
-  word-break: keep-all;
-  background-color: white;
+  ${(props) => {
+    if (props.children) {
+      return css`
+        max-width: 55%;
+        padding: 12px;
+        margin-left: 6px;
+        font-size: 14px;
+        line-height: 17px;
+        border: 1px solid #C4C4C4;
+        border-radius: 0px 10px 10px 10px;
+        word-break: keep-all;
+        background-color: white;
+    `}
+  }}
 `
 
 export const RightChat = styled(LeftChat)`
@@ -37,4 +45,17 @@ export const ChatTime = styled.strong`
   font-size: 10px;
   line-height: 12px;
   color: #404040;
+`
+
+export const ChatImage = styled.img`
+  display: none;
+  ${(props) => {
+    if (props.src) {
+      return css`
+        display: inline;
+        width: 200px;
+        border-radius: 10px;
+      `
+    }
+  }}
 `

--- a/src/components/speechBubble/speechBubbleStyle.js
+++ b/src/components/speechBubble/speechBubbleStyle.js
@@ -5,6 +5,10 @@ export const LeftSpeechBubbleWrapper = styled.div`
   padding: 0 16px;
   margin: 10px 0;
   gap: 6px;
+
+  :first-of-type{
+    margin-top: 48px;
+  }
 `
 
 export const RightSpeechBubbleWrapper = styled(LeftSpeechBubbleWrapper)`
@@ -20,12 +24,12 @@ export const LeftChat = styled.span`
   border: 1px solid #C4C4C4;
   border-radius: 0px 10px 10px 10px;
   word-break: keep-all;
+  background-color: white;
 `
 
 export const RightChat = styled(LeftChat)`
   border-radius: 10px 0 10px 10px;
   margin-left: 0;
-  margin-right: 6px;
 `
 
 export const ChatTime = styled.strong`

--- a/src/components/speechBubble/speechBubbleStyle.js
+++ b/src/components/speechBubble/speechBubbleStyle.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const LeftSpeechBubbleWrapper = styled.div`
+  display: flex;
+  padding: 0 16px;
+  margin: 10px 0;
+  gap: 6px;
+`
+
+export const RightSpeechBubbleWrapper = styled(LeftSpeechBubbleWrapper)`
+  flex-direction: row-reverse;
+`
+
+export const LeftChat = styled.span`
+  max-width: 55%;
+  padding: 12px;
+  margin-left: 6px;
+  font-size: 14px;
+  line-height: 17px;
+  border: 1px solid #C4C4C4;
+  border-radius: 0px 10px 10px 10px;
+  word-break: keep-all;
+`
+
+export const RightChat = styled(LeftChat)`
+  border-radius: 10px 0 10px 10px;
+  margin-left: 0;
+  margin-right: 6px;
+`
+
+export const ChatTime = styled.strong`
+  margin-top: auto;
+  font-size: 10px;
+  line-height: 12px;
+  color: #404040;
+`

--- a/src/template/chat/ChatRoom.jsx
+++ b/src/template/chat/ChatRoom.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { NavBack } from '../../components/navBack/NavBack'
+import { RightSpeechBubble, LeftSpeechBubble } from '../../components/speechBubble/SpeechBubble'
+import { AllWrap } from '../../style/commonStyle'
+import { ChatRoomWrapper, ChatInputWrapper, ChatButton, ChatInput } from './chatRoomStyle'
+import petImage from '../../assets/rang.jpg'
+import profileIcon from '../../assets/basic-profile.svg'
+import { ProfileIconS } from '../../components/profileIcon/ProfileIcon'
+
+export default function ChatRoom() {
+  return (
+    <AllWrap>
+      <NavBack text={'코랑이'} />
+      <ChatRoomWrapper>
+        <LeftSpeechBubble chat={'아랑이랑 산책하고 싶어서 게시글 시간보고 연락드려요~ 6/28 3시 가능하신가요?'} time={'12:39'} />
+        <LeftSpeechBubble chat={'대답 좀 해주세요.'} time={'12:41'} />
+        <RightSpeechBubble chat={'하고있는데요.'} time={'12:50'} />
+        <RightSpeechBubble img={petImage} time={'12:51'} />
+      </ChatRoomWrapper>
+      <ChatInputWrapper>
+        <ProfileIconS img={profileIcon}></ProfileIconS>
+        <ChatInput placeholder='메세지 입력하기...'></ChatInput>
+        <ChatButton>전송</ChatButton>
+      </ChatInputWrapper>
+    </AllWrap>
+  )
+}

--- a/src/template/chat/chatRoomStyle.js
+++ b/src/template/chat/chatRoomStyle.js
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+
+export const ChatRoomWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #D7E7FF;
+`
+
+export const ChatInputWrapper = styled.div`
+  width: 100%;
+  height: 60px;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  gap: 20px;
+  padding: 10px 16px;
+  box-sizing: border-box;
+  background-color: white;
+`
+
+export const ChatInput = styled.input`
+  width: 90%;
+  border: none;
+  :focus {
+    outline: none;
+  }
+`
+
+export const ChatButton = styled.button`
+  width: 40px;
+  font-size: 14px;
+  line-height: 17px;
+  color: #C4C4C4;
+  text-align: right;
+  margin-left: auto;
+
+  :hover {
+    color: #1D57C1;
+  }
+`


### PR DESCRIPTION
* 말풍선의 크기가 가득차지 않도록 width: 55%로 설정
* 문장이 음절단위가 아닌 단어단위로 줄바뀜될 수 있도록 함.
* 메세지 입력하기 부분에 글자수 제한은 따로 하지않았음. (핸드폰 크기에 따라 input길이가 달라지므로 좀 더 고민하는중)
* 상단 내비게이션의 NavWrapper 텍스트 위치문제로 justify-content: space-between 삭제함 
(이로 인해 영향받는 컴포넌트를 다 확인했으나 놓친 2개의 부분이 있어서 머지 후 바로 수정할 계획)


![image](https://user-images.githubusercontent.com/97039896/179262521-e6e7cd65-5d2b-447b-aa21-823bbb00c977.png)

close #129