### PR TITLE
:lipstick: Add : Myprofile 하단부분 등록한 펫 리스트 추가

### DIFF
--- a/src/components/animalBox/AnimalBox.jsx
+++ b/src/components/animalBox/AnimalBox.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import {AnimalWrapper, TitleTxt,TimeTxt,Img} from './animalStyle'
+import { AnimalWrapper, TitleTxt, TimeTxt, Img } from './animalStyle'
 import rang from '../../assets/rang.jpg' //나중에 삭제
 
 //사용법
 // <AnimalBox src={} title={"아랑이랑 산책하실 분"} time={"6월 27일 오후 8시"}/>
-export function AnimalBox(props){
-  return(
+export function AnimalBox(props) {
+  return (
     <AnimalWrapper>
-      <Img src={rang}/>
+      <Img src={props.src} />
       <TitleTxt>{props.title}</TitleTxt>
       <TimeTxt>{props.time}</TimeTxt>
     </AnimalWrapper>

--- a/src/components/animalBox/animalStyle.js
+++ b/src/components/animalBox/animalStyle.js
@@ -4,7 +4,6 @@ export const AnimalWrapper = styled.article`
   cursor: pointer;
   border-radius:10px;
   box-sizing:border-box;
-  overflow:hidden;
   width: 140px;
   height: 132px;
 `
@@ -15,18 +14,22 @@ export const Img = styled.img`
   height: 90px;
 `
 
-export const Txt =styled.p`
+export const Txt = styled.p`
   display:block;
 `
 
 export const TitleTxt = styled(Txt)`
   margin: 7px 2px 4px;
   font-size:13px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `
 
-export  const TimeTxt = styled(Txt)`
+export const TimeTxt = styled(Txt)`
   font-size: 11px;
   color: #1D57C1;
+  margin-left: 3px
 `
 
 

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -3,14 +3,15 @@ import { NavBack } from '../components/navBack/NavBack'
 import { AllWrap } from '../style/commonStyle'
 import MyProfile from '../template/profile/MyProfile'
 import TabMenu from '../components/tabMenu/TabMenu'
+import { PetPost } from '../template/profilePost/PetPost'
 
 
 function MyProfilePage() {
   return (
     <AllWrap>
       <NavBack />
-      <MyProfile>
-      </MyProfile>
+      <MyProfile />
+      <PetPost />
       {/* 작성된 포스팅이 있으면 친구구해요 + 게시글리스트 템플릿 추가 */}
       <TabMenu />
     </AllWrap>

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -4,18 +4,28 @@ import { AllWrap } from '../style/commonStyle'
 import MyProfile from '../template/profile/MyProfile'
 import TabMenu from '../components/tabMenu/TabMenu'
 import { PetPost } from '../template/profilePost/PetPost'
-
+import { selectAllPosts } from '../reducers/getPetInfoSlice'
+import { useSelector } from 'react-redux';
 
 function MyProfilePage() {
+
+  const postLength = useSelector(selectAllPosts).product.length;
+
+  console.log('postLength', postLength)
+
   return (
     <AllWrap>
       <NavBack />
       <MyProfile />
-      <PetPost />
-      {/* 작성된 포스팅이 있으면 친구구해요 + 게시글리스트 템플릿 추가 */}
+      {/* 산책피드가 없는 경우 빈화면 */}
+      {
+        postLength === 0 ? " " : <PetPost />
+      }
+      {/* sns 포스트가 없는 경우 추가 */}
       <TabMenu />
     </AllWrap>
   )
+
 }
 
 export default MyProfilePage

--- a/src/template/profilePost/PetPost.jsx
+++ b/src/template/profilePost/PetPost.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { AnimalBox } from '../../components/animalBox/AnimalBox'
+import { selectAllPosts } from '../../reducers/getPetInfoSlice'
+import { useSelector } from 'react-redux';
+import { MiniPostTitle, MiniPostWrap, SectionAllWrap } from './petPostStyle'
+
+export function PetPost() {
+  const posts = useSelector(selectAllPosts).product;
+
+  return (
+    <>
+      <SectionAllWrap>
+
+        <MiniPostTitle>산책가까?</MiniPostTitle>
+        <MiniPostWrap>
+          {posts && posts.map((post) => {
+            return (
+              <AnimalBox key={post.id}
+                src={`https://mandarin.api.weniv.co.kr/${post.itemImage}`}
+                title={post.itemName} time={post.updatedAt.substring(0, 10)} />
+            )
+          }
+          )}
+        </MiniPostWrap>
+      </SectionAllWrap>
+    </>
+  )
+}

--- a/src/template/profilePost/petPostStyle.js
+++ b/src/template/profilePost/petPostStyle.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+
+export const SectionAllWrap = styled.section`
+padding: 20px 0px 20px 16px;
+box-sizing: border-box;
+border-top:4px solid #E7EFFF;
+border-bottom: 4px solid #E7EFFF;
+`
+
+export const MiniPostTitle = styled.h2`
+font-weight: 400;
+font-size: 16px;
+line-height: 19px;
+margin-bottom: 15px;
+`
+
+export const MiniPostWrap = styled.div`
+display: flex;
+flex-direction: row;
+gap: 10px;
+overflow: auto;
+::-webkit-scrollbar {
+    display: none;
+}
+`


### PR DESCRIPTION
##등록한 펫 리스트 템플릿 추가 

- Myprofile 에서 보이는 펫 등록 리스트 추가
- 구현하면서 관련 컴포넌트 스타일 값 수정
- 스크롤하면 나머지 리스트 보이도록 구현
- 스크롤바는 안보이게 했습니다
- 보더 디자인은 임의로 포스트 구분선과 비슷하게 해놓았습니다 (개인적으로 회색보다는 이게 나았습니당 다른 의견 있으시면 얘기해주세요!)

2commits
- 산책피드에 게시글이 없는경우 PetPost가 랜더링되지않습니다

![image](https://user-images.githubusercontent.com/54096506/179301917-b4a4e1cb-1e19-459c-ad8d-42e8ef3f9c9a.png)

close #146 