### PR TITLE
:sparkles: Feat : Search페이지 라우팅 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import MyProfilePage from './pages/MyProfilePage'
 import ProfileModify from './template/profileModify/ProfileModify'
 import AddPost from './template/post/AddPost';
 import ChatList from './template/chat/ChatList';
+import AccountSearch from './template/search/AccountSearch';
 
 function App() {
   return (
@@ -29,6 +30,7 @@ function App() {
         <Route path='/profilemodify' element={<ProfileModify />}></Route>
         <Route path='/post' element={<AddPost />}></Route>
         <Route path='/chatpage' element={<ChatList />}></Route>
+        <Route path='/search' element={<AccountSearch />}></Route>
       </Routes>
       <AnimatePresence />
 

--- a/src/components/navBack/NavBack.jsx
+++ b/src/components/navBack/NavBack.jsx
@@ -63,9 +63,11 @@ export function NavSearch(props) {
   return (
     <NavWrapper>
       <NavTxt>{props.text}</NavTxt>
-      <NavBtn>
-        <Img src={searchbar} alt="" />
-      </NavBtn>
+      <Link to={props.url}>
+        <NavBtn>
+          <Img src={searchbar} alt="" />
+        </NavBtn>
+      </Link>
     </NavWrapper>
   )
 }

--- a/src/pages/FeedPage.jsx
+++ b/src/pages/FeedPage.jsx
@@ -8,13 +8,15 @@ import TabMenu from '../components/tabMenu/TabMenu'
 export default function FeedPage() {
   const textBtn = "검색하기"
   const textDefault = "유저를 검색해 팔로우 해보세요!"
+  const url = "/search"
+
   return (
     <AllWrap>
       <header>
-        <NavSearch text={"Pet Story"} />
+        <NavSearch text={"Pet Story"} url={url}/>
       </header>
       <main>
-        <FollowCompo textBtn={textBtn} textDefault={textDefault} />
+        <FollowCompo textBtn={textBtn} textDefault={textDefault} url={url}/>
         <AddBtn />
         <TabMenu />
       </main>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -31,7 +31,7 @@ export default function HomePage() {
   return (          
     <AllWrap>
       <header>
-        <NavSearch text={"산책 피드"} />
+        <NavSearch text={"산책 피드"} url={"/search"}/>
       </header>
       {(postsStatus==='idle'&&posts?.length===0) ?<DefaultFeed/>:<WalkingFeed/> }
       <Link to={'/post'}>


### PR DESCRIPTION
## FeedPage
- 검색하기(`textBtn`) 버튼과 아이콘(`searchbar`)을 클릭했을 때 `/search` 페이지로 이동하도록 구현하였습니다.
![image](https://user-images.githubusercontent.com/100080663/179352942-65774828-f0c5-455d-8b6a-1f72732682b4.png)

<br>

## HomePage
- 아이콘(`searchbar`)을 클릭했을 때 `/search` 페이지로 이동하도록 구현하였습니다.
![image](https://user-images.githubusercontent.com/100080663/179353550-66dae7bc-ca4e-49e9-9bec-0509e6c53c13.png)

<br>

## 페이지 이동 후 모습
![image](https://user-images.githubusercontent.com/100080663/179353926-c9406684-2018-4e09-98eb-b7ebbe43a7b9.png)


close #150 