### PR TITLE
💄 Style : 스크롤바 스타일변경, 프로필이미지 원형으로 변경,  프로필펫등록 포스팅 반응형

### DIFF
--- a/src/components/animalBox/animalStyle.js
+++ b/src/components/animalBox/animalStyle.js
@@ -6,12 +6,20 @@ export const AnimalWrapper = styled.article`
   box-sizing:border-box;
   width: 140px;
   height: 132px;
+  @media screen and (min-width:450px) {
+    width: 180px;
+  height: 150px;
+  }
 `
 
 export const Img = styled.img`
   border-radius:10px;
   width: 140px;
   height: 90px;
+  @media screen and (min-width:450px) {
+    width: 180px;
+  height: 110px;
+  }
 `
 
 export const Txt = styled.p`

--- a/src/components/profileIcon/ProfileIcon.jsx
+++ b/src/components/profileIcon/ProfileIcon.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import profileIcon from '../../assets/basic-profile.svg'
 import { IconStyle, ChatIconStyle } from './profileIconStyle'
 
-export function ProfileIconS({img}) {
+export function ProfileIconS({ img }) {
   return (
     <IconStyle src={img} width={40} height={40} />
   )
@@ -14,7 +14,7 @@ export function ProfileIconM() {
   )
 }
 
-export function ChatListProfileIcon({visible}) {
+export function ChatListProfileIcon({ visible }) {
   return (
     <ChatIconStyle visible={visible} />
   )

--- a/src/components/profileIcon/profileIconStyle.js
+++ b/src/components/profileIcon/profileIconStyle.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components'
 import profileIcon from '../../assets/basic-profile.svg'
 
 export const IconStyle = styled.img`
+border-radius: 50%;
 ${(props) => {
     return css`
     width: ${props.width}px;

--- a/src/pages/SignUpMain.jsx
+++ b/src/pages/SignUpMain.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import SignUp from '../template/signUp/SignUp';
 import ProfilePage from '../template/signUp/ProfilePage';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 export async function ImgUpload(userImg) {
 
@@ -29,7 +30,7 @@ export function SignUpMainPage() {
   const [next, setNext] = useState(false)
 
   const url = "https://mandarin.api.weniv.co.kr";
-
+  const navigator = useNavigate();
 
   //유효성 검사를 위한 react-hook-form 변수 선언
   const {
@@ -62,7 +63,10 @@ export function SignUpMainPage() {
     //회원가입 최종 전송
     axios.post(url + '/user', userData,
       { headers: { "Content-type": "application/json" } })
-      .then((res) => console.log('회원가입', res))
+      .then((res) => {
+        console.log('회원가입', res);
+        navigator('/login')
+      })
   }
 
 
@@ -113,12 +117,11 @@ export function SignUpMainPage() {
       })
         .then(
           (res) => {
-            console.log(res);
-            setMessage(res.data.message);
+            console.log('res', res);
+            setMessage(res.data.message)
           });
     }
   }
-
   //다음 버튼
   function nextClick() {
     setNext(true);

--- a/src/style/commonStyle.js
+++ b/src/style/commonStyle.js
@@ -16,7 +16,19 @@ export const ScrollMain = styled.main`
 height: 100%;
 overflow: auto;
 box-sizing: border-box;
-padding: 50px 0;
+padding: 50px 5px;
+::-webkit-scrollbar {
+    width: 7px;
+}
+::-webkit-scrollbar-track {
+    background-color: none;
+
+}
+::-webkit-scrollbar-thumb {
+    background-color: #EdEded;
+    border-radius: 10px;
+
+}
 `
 
 export const PaddingMain = styled.main`

--- a/src/template/profilePost/petPostStyle.js
+++ b/src/template/profilePost/petPostStyle.js
@@ -2,10 +2,10 @@ import styled from 'styled-components';
 
 
 export const SectionAllWrap = styled.section`
-padding: 20px 0px 20px 16px;
+padding: 20px 0px 10px 16px;
 box-sizing: border-box;
 border-top:4px solid #E7EFFF;
-border-bottom: 4px solid #E7EFFF;
+border-bottom:4px solid #E7EFFF;
 `
 
 export const MiniPostTitle = styled.h2`
@@ -20,7 +20,17 @@ display: flex;
 flex-direction: row;
 gap: 10px;
 overflow: auto;
+padding-bottom: 10px;
+
 ::-webkit-scrollbar {
-    display: none;
+    height: 7px;
 }
+::-webkit-scrollbar-track {
+    background-color: none;
+}
+::-webkit-scrollbar-thumb {
+    background-color: #EdEded;
+    border-radius: 10px;
+}
+
 `

--- a/src/template/signUp/ProfilePage.jsx
+++ b/src/template/signUp/ProfilePage.jsx
@@ -11,7 +11,9 @@ function ProfilePage({ userName, setName, userId, setId, userIntro, setIntro, me
         <Title>프로필 설정</Title>
         <Message>나중에 언제든지 변경할 수 있습니다.
         </Message>
-        <ProfileSet userName={userName}
+        <ProfileSet
+          message={message}
+          userName={userName}
           setName={setName}
           userId={userId}
           setId={setId}


### PR DESCRIPTION
- 스크롤 바 스타일 변경 
기존 스크롤 바 없음에서 스타일 변경한 스크롤 바로 변경
 ![image](https://user-images.githubusercontent.com/54096506/179374004-ae6597a9-23ad-4988-8c62-0dcca3e29f22.png)

- 프로필 이미지 원형으로 변경
(게시글 포스팅 프로필이미지 사각형 -> 원형 변경
![image](https://user-images.githubusercontent.com/54096506/179374019-59425cc1-b9ea-4b90-91fa-c724266b05f2.png)

- 프로필 펫등록 포스팅 반응형
![image](https://user-images.githubusercontent.com/54096506/179374025-7dae5fb1-6af0-41b4-ab68-792683b57374.png)
![image](https://user-images.githubusercontent.com/54096506/179374034-2f5e9411-111d-4798-94d6-b7778c542f04.png)
페이지 넓이에 따른 펫등록 포스팅 이미지 넓이 변경

- 스크롤 메인 컴포넌트에도 동일한 스크롤 디자인 적용