### PR TITLE
:sparkles: Feat : 여러이미지업로드(미리보기)

### DIFF
--- a/src/template/snsPost/AddSnsPost.jsx
+++ b/src/template/snsPost/AddSnsPost.jsx
@@ -3,8 +3,40 @@ import { SnsUploadNav } from '../../components/navBack/NavBack'
 import { AllWrap } from '../../style/commonStyle'
 import { FileInput,FileUploader,TextInput,ImgBox,Img,TextLable } from './addSnsPostStyle'
 import { PaddingMain } from '../../style/commonStyle'
+import { useState, useRef, useEffect } from 'react'
+import { useDispatch } from "react-redux";
 
-export default function AddSnsPost() {
+
+export default function AddSnsPost() { 
+  const dispatch = useDispatch();
+  const [showImg, setShowImg] = useState([])
+  const fileInput = useRef(null)
+
+  //서버에 보낼 file객체
+  const [userImg, setImg] = useState("");
+
+  //이미지미리보기
+  const handleAddImg = (e) => {
+    let fileURLs = [...showImg];
+    const fileArr = e.target.files;
+    console.log("fileArr",fileArr);
+    for(let i=0;i<fileArr.length;i++){
+      const currentImgURL = URL.createObjectURL(fileArr[i]);
+      fileURLs.push(currentImgURL);
+    }
+    console.log("현재 저장된 URL",fileURLs);
+    if(fileURLs.length>3){
+      alert("사진은 최대 3장까지 업로드 가능합니다.");
+      fileURLs = fileURLs.slice(0,3); 
+    }
+    setShowImg(fileURLs);
+  }
+  console.log("이미지state값",showImg);
+
+  const handleDeleteImg =(id)=>{
+    setShowImg(showImg.filter((_,index)=>index!==id));
+  };
+
   return (
     <AllWrap>          
       <header>
@@ -14,18 +46,19 @@ export default function AddSnsPost() {
         <TextLable htmlFor="snspost" />
         <TextInput name="snspost" id="snspost"  placeholder="게시글 입력하기 ..."/>
         <ImgBox>
-          <Img/>
-          <Img/>
-          <Img/>
+          {showImg.map((image,id)=>(
+            <Img key={id} src={image} />
+          ))}
         </ImgBox>
         <FileUploader htmlFor="input-file">
           <FileInput
             id="input-file"
-            type="file"
-            accept='image/jpeg, image/jpg'
             name='PostingImg'
-          // onChange={onChange}
-          // ref={fileInput}
+            type="file"
+            multiple
+            accept='image/jpeg, image/jpg'
+            onChange={handleAddImg}
+            ref={fileInput}
           />
         </FileUploader>
       </PaddingMain>


### PR DESCRIPTION
- 여러개의 이미지를 업로드시 브라우저 상에서 미리볼수 있는 기능 구현
- `createObjectURL` 사용

[preview]
- 한장씩 업로드시 최대 3장까지 추가
- 여러장을 동시에 업로드 할 수 있음
- 3장이 넘어가면 alert창이 드고 순서대로 3장만 렌더링

(사진 클릭하는 부분이 안보이긴 하지만 사진을 클릭하고 있습니다 ㅎㅎ,,)
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/83548784/179392327-6a10fc20-bbc1-4435-9219-0c45da7d1158.gif)
  close #153 