### PR TITLE
Feat/피드게시글렌더링

### DIFF
--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -28,11 +28,11 @@ export function UserFollow({ userName, userId }) {
   )
 }
 
-export function UserMore() {
+export function UserMore({userName,userId,img}) {
   return (
     <>
       <Wrapper between>
-        <User />
+        <User userName={userName} userId={userId} img={img} />
         <MoreIcon src={moreIcon} />
       </Wrapper>
     </>

--- a/src/pages/FeedPage.jsx
+++ b/src/pages/FeedPage.jsx
@@ -1,28 +1,40 @@
 import React from 'react'
 import { NavSearch } from '../components/navBack/NavBack'
 import { AllWrap } from '../style/commonStyle'
-import { FollowCompo } from '../components/followCompo/FollowCompo'
 import { AddBtn } from '../components/iconButton/IconButton'
 import TabMenu from '../components/tabMenu/TabMenu'
+import { useSelector,useDispatch} from 'react-redux'
 import { Link } from 'react-router-dom'
-
+import {AxiosPost,selectAllSnsPosts,getSnsPostStatus} from '../reducers/getPostSlice';
+import { useEffect } from 'react'
+import DefaultSnsFeed from '../template/snsFeed/DefaultSnsFeed'
+import SnsFeed from '../template/snsFeed/SnsFeed'
 export default function FeedPage() {
-  const textBtn = "검색하기"
-  const textDefault = "유저를 검색해 팔로우 해보세요!"
+
   const url = "/search"
+  const dispatch = useDispatch();
+  const postsStatus = useSelector(getSnsPostStatus);
+  const URL = "https://mandarin.api.weniv.co.kr";
+  const accountname = JSON.parse(localStorage.getItem("accountname"))
+  const loginReqPath = `/post/${accountname}/userpost`; //내sns게시글
+  const posts = useSelector(selectAllSnsPosts).post;
+
+  useEffect(()=>{
+    if(postsStatus === 'idle'){
+      dispatch(AxiosPost(URL+loginReqPath))
+    }
+  },[dispatch])
 
   return (
     <AllWrap>
       <header>
         <NavSearch text={"Pet Story"} url={url}/>
       </header>
-      <main>
-        <FollowCompo textBtn={textBtn} textDefault={textDefault} url={url}/>
-        <Link to ='/snspost'>
-          <AddBtn />
-        </Link>
-        <TabMenu />
-      </main>
+      {(posts?.length===0) ? <DefaultSnsFeed/>: <SnsFeed/>}
+      <Link to ='/snspost'>
+        <AddBtn />
+      </Link>
+      <TabMenu />
     </AllWrap>
   )
 }

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -1,17 +1,26 @@
-import React from 'react'
+import React,{useEffect} from 'react'
 import { NavBack } from '../components/navBack/NavBack'
 import { AllWrap } from '../style/commonStyle'
 import MyProfile from '../template/profile/MyProfile'
 import TabMenu from '../components/tabMenu/TabMenu'
 import { PetPost } from '../template/profilePost/PetPost'
-import { selectAllPosts } from '../reducers/getPetInfoSlice'
-import { useSelector } from 'react-redux';
+import { useSelector,useDispatch } from 'react-redux';
+import { selectAllPosts,AxiosPetInfo,getPostStatus } from '../reducers/getPetInfoSlice'
+
 
 function MyProfilePage() {
+  const dispatch = useDispatch();
+  const postsStatus = useSelector(getPostStatus);
+  const postLength = useSelector(selectAllPosts).product?.length;
+  const URL = "https://mandarin.api.weniv.co.kr";
+  const accountname = JSON.parse(localStorage.getItem("accountname"))
+  const loginReqPath = `/product/${accountname}/?limit=30`; //내게시글
 
-  const postLength = useSelector(selectAllPosts).product.length;
-
-  console.log('postLength', postLength)
+  useEffect(()=>{
+    if(postsStatus ==='idle'){
+      dispatch(AxiosPetInfo(URL+loginReqPath))
+    }
+  },[dispatch])
 
   return (
     <AllWrap>

--- a/src/reducers/getPostSlice.js
+++ b/src/reducers/getPostSlice.js
@@ -1,0 +1,60 @@
+import {createSlice,createAsyncThunk,current } from "@reduxjs/toolkit";
+import axios from 'axios';
+
+const initialState = {
+  postData: "",
+  status : "idle",
+}
+
+
+export const AxiosPost = createAsyncThunk(
+  'post/axiosPost',
+  async(url) =>{
+    console.log(url);
+    const token = JSON.parse(localStorage.getItem("token")) ;
+    const config = {
+      headers: {
+        "Authorization" : `Bearer ${token}`,
+        "Content-type" : "application/json"
+      },
+    }
+    const res = await axios(url,config);
+    console.log("res.data.product : ",res.data.product);
+    return res.data
+  }
+)
+
+export const postInfoSlice = createSlice({
+  name : "getPost",
+  initialState,
+  reducers:{
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(AxiosPost.pending, (state) => {
+        console.log("로드중");
+        state.status = 'loading';
+      })
+      .addCase(AxiosPost.fulfilled, (state, action) => {
+        console.log("성공",action);
+        state.status = 'idle';
+        state.postData = action.payload;
+        console.log(current(state));
+      })
+      .addCase(AxiosPost.rejected,(state,action) => {
+        console.log("실패");
+        state.state = 'fail';
+      });
+  },
+})
+
+console.log("postInfoSlice",postInfoSlice);
+
+export const selectAllSnsPosts = (state) =>state.getPost.postData;
+
+
+export const getSnsPostStatus = (state) => state.getPost.status;
+
+export default  postInfoSlice.reducer;
+
+export const postActions = postInfoSlice.actions;

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import Reducer from './reducers/Reducer'
 import getPetInfoReducer from './reducers/getPetInfoSlice'
+import getPostReducer from "./reducers/getPostSlice";
 
 //추후고려
 // const userToken = localStorage.getItem("userInfo")
@@ -15,6 +16,7 @@ export const store = configureStore({
   reducer:{
     // initialState,
     getPetInfo:getPetInfoReducer,
+    getPost:getPostReducer
     // uploadPost:Reducer, 보류
   },
 })

--- a/src/template/snsFeed/DefaultSnsFeed.jsx
+++ b/src/template/snsFeed/DefaultSnsFeed.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { FollowCompo } from '../../components/followCompo/FollowCompo'
+
+export default function DefaultSnsFeed() {
+  const textBtn = "검색하기"
+  const textDefault = "유저를 검색해 팔로우 해보세요!"
+  const url = "/search"
+  return (
+    <main>
+      <FollowCompo textBtn={textBtn} textDefault={textDefault} url={url}/>
+    </main>
+  )
+}

--- a/src/template/snsFeed/SnsFeed.jsx
+++ b/src/template/snsFeed/SnsFeed.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { ScrollMain } from '../../style/commonStyle'
+import SnsPost from '../snsPost/SnsPost'
+
+export default function SnsFeed() {
+  return (
+    <ScrollMain>
+      <SnsPost/>
+    </ScrollMain>
+  )
+}

--- a/src/template/snsPost/SnsPost.jsx
+++ b/src/template/snsPost/SnsPost.jsx
@@ -1,27 +1,56 @@
 import React from 'react'
 import { UserMore } from '../../components/user/User.jsx'
-import { IconWrap, PostImg, PostText, WrapperArticle, WrapSection, IconImg, DateText, MoreIcon } from './snsPostStyle'
+import { IconWrap, PostImg, PostText, WrapperArticle, WrapSection, IconImg, DateText } from './snsPostStyle'
 import image from '../../assets/basic-profile.svg'
 import heartIcon from '../../assets/icon-heart.svg'
 import messageIcon from '../../assets/icon-message.svg'
+import { useSelector } from 'react-redux';
+import { selectAllSnsPosts } from '../../reducers/getPostSlice.js'
 
 function SnsPost() {
-  return (
-    <article>
-      <WrapperArticle>
-        <UserMore />
-        <WrapSection>
-          <PostText>우리 아랑이가 드디어 코딩을 할 줄 알아요..!! 우리 애기 천재💗🐿️</PostText>
-          <PostImg src={image} />
-          <IconWrap>
-            <IconImg src={heartIcon} />38
-            <IconImg src={messageIcon} />55
-          </IconWrap>
-          <DateText>2022년 07월 01일</DateText>
-        </WrapSection>
-      </WrapperArticle>
+  const  snsPosts = useSelector(selectAllSnsPosts).post;
+  console.log(snsPosts);
+  const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png";
+  const marketImg = "http://146.56.183.55:5050/Ellipse.png";
 
-    </article>
+  function imgCheck(post) {
+    if (post.author.image === marketImg) {
+      return defaultImg;
+    }
+    else {
+      return "https://mandarin.api.weniv.co.kr/" + post.author.image;
+    }
+  }
+
+  return (
+    <ul>
+      { snsPosts && snsPosts.map((post)=>{
+        let images = post.image
+        images = images.split(",")
+        console.log(images);
+        return(
+          <li key={post.id} style={{margin:"30px 0"}}>
+            <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)}/>
+            <WrapSection>
+              <PostText>{post.content}</PostText>
+              { images.map((image)=>{
+                console.log("https://mandarin.api.weniv.co.kr/"+image);
+                return(
+                  <>
+                    <PostImg src={"https://mandarin.api.weniv.co.kr/"+image} />
+                  </>
+                )
+              })}
+              <IconWrap>
+                <IconImg src={heartIcon} />38
+                <IconImg src={messageIcon} />55
+              </IconWrap>
+              <DateText>{post.updatedAt.substring(0, 10)}</DateText>
+            </WrapSection>
+          </li>
+        )
+      })}
+    </ul>
   )
 }
 

--- a/src/template/snsPost/snsPostStyle.js
+++ b/src/template/snsPost/snsPostStyle.js
@@ -4,7 +4,7 @@ export const WrapperArticle = styled.article`
 width: 100%;
 `
 
-export const WrapSection = styled.section`
+export const WrapSection = styled.div`
 padding-left: 45px;
 `
 
@@ -36,7 +36,7 @@ export const IconImg = styled.img`
 background-color: none;
 width: 20px;
 height: 20px;
-border: tr a nsparent;
+border: transparent;
 vertical-align: -5px;
 margin: 0 6px 0px 15px;
 :first-child{


### PR DESCRIPTION
**1commit**
-  `/feedpage`의 sns게시글을 RTK와 thunk를 이용하여 get요청

**2commit**
- `/feedpage`에서 게시글의 상태에 따라 페이지를 다르게 라우팅 시켜야하므로 메인 분리 (pet 게시글과 동일)

**3commit**
- sns게시글을  `/feedpage`에 렌더링 

**4commit**
- 프로필페이지 url로 접근시 에러, 값이 읽히기 전 불러오는 부분을 `dispatch`로 잡음

close #159 