### PR TITLE
:sparkles: Feat : url로 직접 접근시 조건부렌더링

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import GlobalStyles from './style/globalStyle';
-import { Route, Routes } from 'react-router-dom'
+import { Route, Routes,Navigate,useNavigate } from 'react-router-dom'
 import HomePage from './pages/HomePage';
 import FeedPage from './pages/FeedPage';
 import InitPage from './pages/InitPage';
@@ -15,30 +15,34 @@ import AccountSearch from './template/search/AccountSearch';
 import Follow from './template/follow/Follow';
 import ChatRoom from './template/chat/ChatRoom';
 import AddSnsPost from './template/snsPost/AddSnsPost';
+import NotFound from './pages/NotFoundPage';
+
 function App() {
+  const token =!!localStorage.getItem("token");
+  console.log(token);
   return (
     <>
       <GlobalStyles />
       <AnimatePresence />
       <Routes>
+        {/* public page */}
         <Route path='/' element={<InitPage />}></Route>
-        {/* 굳이 URL을 바꿀 필요가 없을것 같음. */}
-        {/* <Route path='/main' element={<Main/>}> </Route> */}
-        <Route path='/login' element={<Login />}></Route>
-        <Route path='/join' element={<SignUpMainPage />}> </Route>
-        <Route path='/homepage' element={<HomePage />}></Route>
-        <Route path='/feedpage' element={<FeedPage />}></Route>
-        <Route path='/profilepage' element={<MyProfilePage />}></Route>
-        <Route path='/profilemodify' element={<ProfileModify />}></Route>
-        <Route path='/post' element={<AddPost />}></Route>
-        <Route path='/snspost' element={<AddSnsPost/>}></Route>
-        <Route path='/chatpage' element={<ChatList />}></Route>
-        <Route path='/search' element={<AccountSearch />}></Route>
-        <Route path='/follow' element={<Follow />}></Route>
-        <Route path='/chatroom' element={<ChatRoom />}></Route>
+        <Route path='/login' element={token?<Navigate to ='/homepage'/> :<Login />}></Route>
+        <Route path='/join' element={token?<Navigate to ='/homepage'/> :<SignUpMainPage />}> </Route>
+        {/* private page */}
+        <Route path='/homepage' element={token? <HomePage/> : <Navigate to ='/'/>}> </Route>
+        <Route path='/feedpage' element={token ? <FeedPage /> : <Navigate to ='/'/>}></Route>
+        <Route path='/profilepage' element={token ?<MyProfilePage /> : <Navigate to ='/'/>}></Route>
+        <Route path='/profilemodify' element={token? <ProfileModify /> :<Navigate to ='/'/>}></Route>
+        <Route path='/post' element={token? <AddPost />:<Navigate to ='/'/>}></Route>
+        <Route path='/snspost' element={token? <AddSnsPost/>:<Navigate to ='/'/>}></Route>
+        <Route path='/chatpage' element={token? <ChatList />:<Navigate to ='/'/>}></Route>
+        <Route path='/search' element={token? <AccountSearch />:<Navigate to ='/'/>}></Route>
+        <Route path='/follow' element={token? <Follow />:<Navigate to ='/'/>}></Route>
+        <Route path='/chatroom' element={token? <ChatRoom />:<Navigate to ='/'/>}></Route>
+        <Route path="/*" element={<NotFound/>}></Route>
       </Routes>
       <AnimatePresence />
-
     </>
   )
 }

--- a/src/components/followCompo/FollowCompo.jsx
+++ b/src/components/followCompo/FollowCompo.jsx
@@ -3,8 +3,7 @@ import { FollowCompoWrapper, DefaultImg, DefaultTxt } from './followCompoStyle'
 import grayLogo from '../../assets/gray-logo.svg'
 import logo404 from '../../assets/404-logo.svg'
 import { MiddleBtn } from '../../components/button/Button'
-import { Link } from "react-router-dom";
-
+import { Link,useNavigate } from "react-router-dom";
 
 export function FollowCompo(props) {
   return (
@@ -21,13 +20,14 @@ export function FollowCompo(props) {
 }
 
 export function NotFoundCompo() {
+  const navigate = useNavigate();
   return (
     <FollowCompoWrapper>
       <img src={logo404} />
       <DefaultTxt>
         페이지를 찾을 수 없습니다. :(
       </DefaultTxt>
-      <MiddleBtn textBtn={'이전 페이지'} />
+      <MiddleBtn textBtn={'이전 페이지'} onClickFt={()=>navigate(-1)}/>
     </FollowCompoWrapper>
   )
 }


### PR DESCRIPTION


### 로그인 되어있을때 homepage로 리다이렉팅되는 페이지
1. `/`  :  splash 페이지
2. `/login` : 로그인페이지
3. `/join` : 회원가입 페이지




### 로그인 여부에 따라 제한되어야 할 페이지들

- token값 여부에 따라 조건부렌더링
- token값이 없다면 전부 splash로 리다이렉트
1. `/homepage` :  펫 정보가 올라간 게시글
2. `/feedpage` : 소통하는 sns게시글
3. `/profilepage` : 내프로필페이지 / 펫정보게시글,소통게시글 둘다있음
4. `/profilemodify` : 내 프로필 수정페이지
5. `/post` :  반려정보 게시글 등록하는 페이지
6. `/snspost` : 자유소통게시글 등록
7. `/chatpage` :  채팅목록페이지
8. `/search` :  유저계정검색 페이지 
9. `/follow` :  팔로우 한 유저정보가 있는 페이지
10. `/chatroom` : 채팅방페이지


### 그밖에 라우팅되지않은 URL 입력시
- 404page
- 404page 뒤로가기 onClick이벤트 구현

close #165 