### PR TITLE
:sparkles: Feat : 마이페이지 내게시글 랜더링 앨범형까지 구현완료

### DIFF
--- a/src/template/profilePost/MyProfileSnsPost.jsx
+++ b/src/template/profilePost/MyProfileSnsPost.jsx
@@ -5,6 +5,7 @@ import listOn from '../../assets/icon-post-list-on.svg'
 import albumOff from '../../assets/icon-post-album-off.svg'
 import albumOn from '../../assets/icon-post-album-on.svg'
 import { MySnsPost } from '../snsPost/SnsPost'
+import SnsAlbum from './SnsAlbum'
 
 function MyProfileSnsPost() {
   const [isList, setIsList] = useState(true)
@@ -37,7 +38,7 @@ function MyProfileSnsPost() {
             <ShowBtnStyle showIcon={albumOn}
               onClick={albumClick} />
           </ShowWrap>
-          <MySnsPost />
+          <SnsAlbum />
         </section>
       }
     </>

--- a/src/template/profilePost/SnsAlbum.jsx
+++ b/src/template/profilePost/SnsAlbum.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { AlbumImage, AlbumWrap } from './SnsAlbumStyle'
+import { selectAllSnsPosts } from '../../reducers/getPostSlice.js'
+import { useSelector } from 'react-redux';
+import test from '../../assets/rang.jpg'
+
+export function SnsAlbum() {
+  const snsPosts = useSelector(selectAllSnsPosts).post;
+  console.log('sns', snsPosts)
+  return (
+    <AlbumWrap>
+      {snsPosts && snsPosts.map((post) => {
+        return (
+          <AlbumImage key={post.id}
+            src={"https://mandarin.api.weniv.co.kr/" + post.image}
+          />
+        )
+      })}
+    </AlbumWrap>
+  )
+}
+
+export default SnsAlbum

--- a/src/template/profilePost/SnsAlbumStyle.js
+++ b/src/template/profilePost/SnsAlbumStyle.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const AlbumWrap = styled.div`
+padding: 10px;
+box-sizing: border-box;
+width: 100%;
+display: grid;
+grid-template-columns: repeat(3,1fr);
+gap: 10px;
+`
+
+export const AlbumImage = styled.img`
+width: 100%;
+height: 111px;
+object-fit: cover;
+@media screen and (min-width: 450px){
+height: 130px;
+}
+@media screen and (min-width:600px){
+  height: 181px;
+}
+`


### PR DESCRIPTION
## 마에 페이지 내 게시글 앨범형으로 랜더링 구현 완료
![image](https://user-images.githubusercontent.com/54096506/179550378-eb2e67c9-de95-4ced-bb10-ca7a4af352a7.png)

- 화면 비율 이슈
일정한 비율을 주고싶었는데, grid row를 정해주자니 게시글이 특정 갯수 이상 올렸을때 UI가 깨지게 되어 row는 정해주지 않은채로 높이를 픽스해주었습니다 
우선 화면 넓이에 따른 3단계 변화로 구현하였는데 피드백 부탁드립니다! 
![image](https://user-images.githubusercontent.com/54096506/179550337-1d6987d2-175e-4e5f-8fac-a67699571b32.png)

close #168 