### PR TITLE
Feat/내프로필sns게시글삭제

### DIFF
--- a/src/components/deleteAlert/DeleteAlert.jsx
+++ b/src/components/deleteAlert/DeleteAlert.jsx
@@ -4,6 +4,7 @@ import { AlertOver, AlertWrapper, DeleteTxt, DeleteAlertBtn, BtnTxt, RedTxt } fr
 import { useSelector, useDispatch } from 'react-redux'
 import { DeleteType, AxiosDeletePost, DeleteId ,selectDeleteMsg } from '../../reducers/deletePostSlice'
 import { AxiosPetInfo } from '../../reducers/getPetInfoSlice';
+import {AxiosPost} from '../../reducers/getPostSlice'
 
 export function DeleteAlert({ mainTxt, rightBtnTxt, closeAlert,setModal }) {
   const dispatch = useDispatch();
@@ -23,9 +24,8 @@ export function DeleteAlert({ mainTxt, rightBtnTxt, closeAlert,setModal }) {
     const URL = "https://mandarin.api.weniv.co.kr";
     const loginReqPath = `/${postType}/${Id}`;  //타입 : sns인지 pet인지
     dispatch(AxiosDeletePost(URL+loginReqPath))
-      .then( 
-        () => dispatch(AxiosPetInfo(URL + `/product/${accountname}`))
-      )
+      .then(  () => postType==='product'&&dispatch(AxiosPetInfo(URL + `/product/${accountname}`)))
+      .then( ()=> postType==='post'&&dispatch((AxiosPost(URL + `/post/${accountname}/userpost`))));
     setModal(false);
   } 
   

--- a/src/components/postModal/PostModal.jsx
+++ b/src/components/postModal/PostModal.jsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { DeleteAlert } from '../deleteAlert/DeleteAlert'
 import { ModalList, ModalWrapper, TopSytle, ModalOver } from './postModalStyle'
-import { useSelector,useDispatch } from 'react-redux/es/exports'
-import { getDeleteStatus,deleteActions,clickType } from '../../reducers/deletePostSlice'
 export default function Modal({ list, closeModal, alertTxt, setModal }) {
 
   // 테스트를 위해 넣어둔 값. 나중에 지울 부분입니다.
@@ -11,11 +9,6 @@ export default function Modal({ list, closeModal, alertTxt, setModal }) {
   // const list2 = ['채팅방 나가기', '신고하기'];
   // const list3 = ['설정 및 개인정보', '로그아웃'];
 
-  const dispatch = useDispatch();
-  // const status = useSelector(getDeleteStatus); // sucess일경우 모달 닫음
-  // console.log(status);
-  // const clickState =useSelector(clickType);
-  // console.log(clickState);
   const [alert, setAlert] = useState(false)
   const showAlert = () => {
     setAlert(alert=>!alert);
@@ -27,17 +20,6 @@ export default function Modal({ list, closeModal, alertTxt, setModal }) {
     setAlert(false)
   }
 
-
-  // setAlert(true)
-
-  // useEffect(()=>{
-  //   console.log("😅",clickState);
-  //   if(clickState ===true){
-  //     dispatch(deleteActions.click(false)) //그후 false
-  //     setAlert(true); 
-  //   }
-  // },[])
- 
   return (
     <ModalOver>
       <ModalWrapper>
@@ -55,5 +37,4 @@ export default function Modal({ list, closeModal, alertTxt, setModal }) {
       {alert === true && <DeleteAlert mainTxt={alertTxt[0]} rightBtnTxt={alertTxt[1]} closeAlert={closeAlert} setModal={setModal}></DeleteAlert>}
     </ModalOver >
   )
- 
 }

--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -28,12 +28,12 @@ export function UserFollow({ userName, userId }) {
   )
 }
 
-export function UserMore({userName,userId,img}) {
+export function UserMore({userName,userId,img,onClick}) {
   return (
     <>
       <Wrapper between>
         <User userName={userName} userId={userId} img={img} />
-        <MoreIcon src={moreIcon} />
+        <MoreIcon src={moreIcon} onClick={onClick}/>
       </Wrapper>
     </>
   )

--- a/src/components/user/userStyle.js
+++ b/src/components/user/userStyle.js
@@ -40,6 +40,7 @@ export const MoreIcon = styled.img`
   width: 24px;
   height: 24px;
   float: right;
+  cursor: pointer;
 `
 
 

--- a/src/template/profilePost/PetPost.jsx
+++ b/src/template/profilePost/PetPost.jsx
@@ -4,7 +4,7 @@ import { selectAllPosts } from '../../reducers/getPetInfoSlice'
 import { useSelector, useDispatch } from 'react-redux'
 import { MiniPostTitle, MiniPostWrap, SectionAllWrap } from './petPostStyle'
 import Modal from '../../components/postModal/PostModal';
-import { deleteActions,getDeleteStatus } from '../../reducers/deletePostSlice'
+import { deleteActions } from '../../reducers/deletePostSlice'
 
 export function PetPost() {
   const dispatch = useDispatch();

--- a/src/template/snsPost/SnsPost.jsx
+++ b/src/template/snsPost/SnsPost.jsx
@@ -1,10 +1,13 @@
-import React from 'react'
+import React,{useState} from 'react'
 import { UserMore } from '../../components/user/User.jsx'
 import { IconWrap, PostImg, PostText, WrapSection, IconImg, DateText } from './snsPostStyle'
 import heartIcon from '../../assets/icon-heart.svg'
 import messageIcon from '../../assets/icon-message.svg'
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectAllSnsPosts } from '../../reducers/getPostSlice.js'
+import { deleteActions } from '../../reducers/deletePostSlice'
+import Modal from '../../components/postModal/PostModal';
+
 
 export function SnsPost() {
   const snsPosts = useSelector(selectAllSnsPosts).post;
@@ -55,10 +58,12 @@ export function SnsPost() {
 
 
 export function MySnsPost() {
+  const dispatch = useDispatch();
   const snsPosts = useSelector(selectAllSnsPosts).post;
   const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png";
   const marketImg = "http://146.56.183.55:5050/Ellipse.png";
 
+  //기본이미지체크함수
   function imgCheck(post) {
     if (post.author.image === marketImg) {
       return defaultImg;
@@ -68,34 +73,52 @@ export function MySnsPost() {
     }
   }
 
+  //모달
+  const list = {'삭제':'','수정':'/'};
+  const alertTxt=['삭제하시겠어요?','삭제'];
+  const [modal, setModal] = useState(false);
+
+  const closeModal = () => {
+    setModal(false)
+  }
+
+  const handleId = (snsId) => {
+    dispatch(deleteActions.checkType("post"));
+    dispatch(deleteActions.deleteId(snsId));
+    setModal(modal => !modal)
+  }
+  
   return (
-    <ul>
-      {snsPosts && snsPosts.map((post) => {
-        let images = post.image
-        images = images.split(",")
-        // console.log(images);
-        return (
-          <li key={post.id} style={{ padding: "16px" }}>
-            <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} />
-            <WrapSection>
-              <PostText>{post.content}</PostText>
-              {images.map((image) => {
-                return (
-                  <>
-                    <PostImg src={"https://mandarin.api.weniv.co.kr/" + image} />
-                  </>
-                )
-              })}
-              <IconWrap>
-                <IconImg src={heartIcon} />38
-                <IconImg src={messageIcon} />55
-              </IconWrap>
-              <DateText>{post.updatedAt.substring(0, 10)}</DateText>
-            </WrapSection>
-          </li>
-        )
-      })}
-    </ul>
+    <>
+      { 
+        modal=== true && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />}
+      <ul>
+        {snsPosts && snsPosts.map((post) => {
+          let images = post.image
+          images = images.split(",")
+          return (
+            <li key={post.id} style={{ padding: "16px" }}>
+              <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} onClick={()=> handleId(post.id)}/>
+              <WrapSection>
+                <PostText>{post.content}</PostText>
+                {images.map((image) => {
+                  return (
+                    <>
+                      <PostImg src={"https://mandarin.api.weniv.co.kr/" + image} />
+                    </>
+                  )
+                })}
+                <IconWrap>
+                  <IconImg src={heartIcon} />
+                  <IconImg src={messageIcon} />
+                </IconWrap>
+                <DateText>{post.updatedAt.substring(0, 10)}</DateText>
+              </WrapSection>
+            </li>
+          )
+        })}
+      </ul>
+    </>
   )
 }
 


### PR DESCRIPTION
- 내 프로필에 있는 sns게시글 삭제기능 구현했습니다.
- pet게시글을 삭제할 때 사용한 같은 reducer함수를 이용하여 삭제합니다.

_**_commit1_**_
- 모달 UI 띄우기 및 게시글id와 종류 `dispatch`

_**_commit2_**_
- 삭제 후 게시글이 업데이트 되도록 설정 
- 버튼에 `cursor:pointer;`

 close #192 