### PR TITLE
:bug: Modify : 프로필 사진 업로드 최대용량 제한

### DIFF
--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -16,6 +16,19 @@ export function Profile({ setImg }) {
       setShowImg("https://mandarin.api.weniv.co.kr/1657812669741.png")
       return
     }
+
+    if (e.target.files && e.target.files[0]) {
+      //10mb로 최대용량 지정
+      let maxSize = 10 * 1024 * 1024;
+      let fileSize = e.target.files[0].size;
+
+      if (fileSize > maxSize) {
+        alert("첨부파일 사이즈는 10MB 이내로 등록 가능합니다.");
+        setShowImg("https://mandarin.api.weniv.co.kr/1657812669741.png")
+        return false;
+      }
+    }
+
     //화면에 프로필 사진 표시
     // 파일리더
     const reader = new FileReader();
@@ -70,6 +83,18 @@ export function ProfileModifyShow({ setImg, userInfoList }) {
     } else { //업로드 취소할 시
       setShowImg("https://mandarin.api.weniv.co.kr/1657812669741.png")
       return
+    }
+
+    if (e.target.files && e.target.files[0]) {
+      //10mb로 최대용량 지정
+      let maxSize = 10 * 1024 * 1024;
+      let fileSize = e.target.files[0].size;
+
+      if (fileSize > maxSize) {
+        alert("첨부파일 사이즈는 10MB 이내로 등록 가능합니다.");
+        setShowImg(userInfoUrl)
+        return false;
+      }
     }
     //화면에 프로필 사진 표시
     // 파일리더


### PR DESCRIPTION
프로필 업로드 시 10mb 이상의 파일의 경우 
에러 발생하여 최대 용량 제한으로 해결

- 10mb이상의 파일이 업로드 되면  alert 출력 후 이미지 등록 취소됨. 이후 초기 사용자 프로필 이미지로 변경 
- 회원 가입, 프로필 수정 모두 적용 / 회원 가입의 경우 기본 이미지로 취소 됨

![image](https://user-images.githubusercontent.com/54096506/179898290-6b58849f-9c33-4963-a375-2dafa42e7a41.png)

close #172 