### PR TITLE
:sparkles: Feat : 계정 검색 결과와 일치하는 문자 색상 변경

### DIFF
--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -6,8 +6,8 @@ import { TextWrapper, UserId, UserName, Wrapper, MoreIcon, ChatPreview, ChatDate
 import moreIcon from '../../assets/icon-more-vertical-small.svg'
 import { Link } from 'react-router-dom'
 
+export function User({ userName, userId, img, keyword}) {
 
-export function User({ userName, userId, img }) {
   return (
     <Wrapper>
       {
@@ -18,7 +18,18 @@ export function User({ userName, userId, img }) {
           <ProfileIconS img={img} />
       }
       <TextWrapper>
-        <UserName>{userName}</UserName>
+        {/* 입력한 결괏값이랑 일치하는 문자 색상 변경 */}
+        {
+          userName.includes(keyword)
+            ? 
+            <>
+              <UserName style={{color: "#1D57C1"}}>{keyword}</UserName>
+            </>
+            : 
+            <>
+              <UserName>{userName}</UserName>
+            </>
+        }
         <UserId>@ {userId}</UserId>
       </TextWrapper>
     </Wrapper>

--- a/src/template/search/AccountSearch.jsx
+++ b/src/template/search/AccountSearch.jsx
@@ -9,7 +9,6 @@ import { AllWrap } from '../../style/commonStyle'
 import { FollowMain } from '../follow/followStyle'
 import { Link } from 'react-router-dom'
 
-
 function AccountSearch() {
   const [searchResult, setSearchResult] = useState([])
   const [keyword, setKeyword] = useState('')
@@ -37,15 +36,29 @@ function AccountSearch() {
   return (
     <AllWrap>
       <header>
-        <NavTxtSearch placeholder={"계정 검색"} onChange={(e) => setKeyword(e.target.value)} ></NavTxtSearch>
+        <NavTxtSearch 
+          placeholder={"계정 검색"} 
+          onChange={(e) => setKeyword(e.target.value)} >
+        </NavTxtSearch>
       </header>
 
       <FollowMain>
         {searchResult.map((user) => {
           console.log(user.image)
-          return <Link key={user._id} to='/userprofile' state={{ userId: user.accountname }}>
-            <User userName={user.username} userId={user.accountname} img={`https://mandarin.api.weniv.co.kr/${user.image}`} />
-          </Link>
+
+          return (
+            <Link 
+              key={user._id}
+              to='/userprofile' 
+              state={{ userId: user.accountname }}>
+              <User 
+                userName={user.username} 
+                userId={user.accountname} 
+                img={`https://mandarin.api.weniv.co.kr/${user.image}`} 
+                keyword={keyword}
+              />
+            </Link>
+          )
         })}
         {searchResult.length === 0 && keyword.length >= 1 && <CorrectMessageStyle>검색된 결과가 없습니다.</CorrectMessageStyle>}
         {/* 검색된 계정이 0개, 입력된 keyword가 1개 이상이면 출력 */}


### PR DESCRIPTION
# 구현 및 변경사항
- 계정 검색 결괏값과 일치하는 `useName`은 색상이 `#404040` -> `#1D57C1` 바뀌도록 구현하였습니다.
- `useId`는 색상이 변경되지 않습니다.
- 가독성의 이유로 아래  컴포넌트 `props` 코드 구조를 변경(줄바꿈) 하였습니다.
  - `NavTxtSearch`, `Link`,  `User` 

<br>

# 결과
![](https://velog.velcdn.com/images/nu11/post/5b2a4dc1-0e42-4fd4-ba9c-b34009512c28/image.gif)

close #175 