### PR TITLE
:sparkles: Feat : 게시글 상세페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import { PrivateRoute, PublicRoute } from './Route';
 import YourProfilePage from './pages/YourProfilePage';
 import ModifyPost from './template/postModify/PostModify';
 import ModifySnsPost from './template/snsPostModify/SnsPostModify';
+import FeedPostDetail from './template/postDetail/FeedPostDetail';
 
 function App() {
   return (
@@ -41,6 +42,7 @@ function App() {
         <Route path='/postmodify' element={<PrivateRoute>< ModifyPost/></PrivateRoute>}></Route>
         <Route path='/snspost' element={<PrivateRoute><AddSnsPost /></PrivateRoute>}></Route>
         <Route path='/snspostmodify' element={<PrivateRoute><ModifySnsPost/></PrivateRoute>}></Route>
+        <Route path='/postdetail' element={<PrivateRoute><FeedPostDetail/></PrivateRoute>}></Route>
         <Route path='/chatpage' element={<PrivateRoute><ChatList /></PrivateRoute>}></Route>
         <Route path='/search' element={<PrivateRoute><AccountSearch /></PrivateRoute>}></Route>
         <Route path='/myfollow' element={<PrivateRoute><MyFollow /></PrivateRoute>}></Route>

--- a/src/components/comment/Comment.jsx
+++ b/src/components/comment/Comment.jsx
@@ -1,17 +1,15 @@
 import React from 'react'
+import { ProfileIconS } from '../profileIcon/ProfileIcon'
 import { CommentBtnStyled, CommentTextStyle, Wrapper } from './commentStyle'
-import { ProfileIconS } from '../../profileIcon/ProfileIcon'
 
-export function Comment() {
+export default function Comment({ img }) {
   return (
     <>
       <Wrapper>
-        <ProfileIconS />
+        <ProfileIconS img={img}></ProfileIconS>
         <CommentTextStyle
           placeholder='댓글 입력하기...' />
         <CommentBtnStyled type='submit'>게시</CommentBtnStyled>
-
-
       </Wrapper>
     </>
   )

--- a/src/components/comment/commentStyle.js
+++ b/src/components/comment/commentStyle.js
@@ -2,37 +2,41 @@ import styled from 'styled-components';
 import { palette } from '../../style/globalColor';
 
 export const Wrapper = styled.div`
-width: 100%;
-padding: 10px;
-color: ${palette.lightGray};
-font-size: 14px;
-line-height: 17px;
-box-sizing: border-box;
+  display: flex;
+  gap: 18px;
+  width: 100%;
+  padding: 12px 16px;
+  position: fixed;
+  bottom: 0;
+  color: ${palette.lightGray};
+  font-size: 14px;
+  line-height: 17px;
+  box-sizing: border-box;
+  border-top: 1px solid ${palette.lightGray};
+  background-color: white;
 `
 
 export const CommentTextStyle = styled.input`
-font-size: 14px;
-line-height: 17px;
-margin: 10px 20px;
-border: none;
-vertical-align: top;
-::placeholder{
-  color: ${palette.lightGray};
-font-size: 14px;
-}
-:focus{
-  outline: none;
-}
+  font-size: 14px;
+  line-height: 17px;
+  border: none;
+  
+  ::placeholder{
+    color: ${palette.lightGray};
+    font-size: 14px;
+  }
+  :focus{
+    outline: none;
+  }
 `
 
 export const CommentBtnStyled = styled.button`
-margin: 10px;
-vertical-align:top;
-font-size: 14px;
-line-height: 17px;
-color: ${palette.lightGray};
-background-color: transparent;
-border: none;
-padding: 0;
-float: right;
+  font-size: 14px;
+  line-height: 17px;
+  color: ${palette.lightGray};
+  margin-left: auto;
+
+  :hover {
+    color: ${palette.textPoint};
+  }
 `

--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -49,6 +49,7 @@ export default function FeedPost({ post }) {
       }
       <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} onClick={() => handleId(post.id)} />
       <WrapSection onClick={() => {
+        dispatch(deleteActions.selectId(post.id));
         dispatch(AxiosDetail(url + `/post/${post.id}`));
       }}>
         <Link to='/postdetail'>

--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -1,26 +1,69 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { deleteActions } from '../../reducers/deletePostSlice'
 import { UserMore } from '../user/User.jsx'
 import { WrapSection, PostText, PostImg, DateText, IconWrap, IconImg } from './feedPostStyle'
 import heartIcon from '../../assets/icon-heart.svg'
 import messageIcon from '../../assets/icon-message.svg'
+import Modal from '../../components/postModal/PostModal';
+import { useDispatch } from 'react-redux';
+import { AxiosDetail } from '../../reducers/getPostDetailSlice';
 
-export default function FeedPost({ post, imgCheck, handleId }) {
+
+export default function FeedPost({ post }) {
+  const dispatch = useDispatch();
+  const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png";
+  const marketImg = "http://146.56.183.55:5050/Ellipse.png";
+  const MyId = JSON.parse(localStorage.getItem("accountname"));
+  const url = "https://mandarin.api.weniv.co.kr";
   const images = post.image.split(",");
+
+  function imgCheck(post) {
+    if (post.author.image === marketImg) {
+      return defaultImg;
+    }
+    else {
+      return "https://mandarin.api.weniv.co.kr/" + post.author.image;
+    }
+  }
+
+  //모달
+  const list = { '삭제': '', '수정': '/snspostmodify' };
+  const alertTxt = ['삭제하시겠어요?', '삭제'];
+  const [modal, setModal] = useState(false);
+
+  const closeModal = () => {
+    setModal(false)
+  }
+
+  const handleId = (snsId) => {
+    dispatch(deleteActions.checkType("post"));
+    dispatch(deleteActions.selectId(snsId));
+    setModal(modal => !modal)
+  }
+
   return (
     <>
+      {
+        (modal === true) && (post.author.accountname === MyId) && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />
+      }
       <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} onClick={() => handleId(post.id)} />
-      <WrapSection>
-        <PostText>{post.content}</PostText>
-        {images.map((image) => {
-          return (
-            <PostImg key={Math.random() * 100} src={"https://mandarin.api.weniv.co.kr/" + image} />
-          )
-        })}
-        <IconWrap>
-          <IconImg src={heartIcon} />
-          <IconImg src={messageIcon} />
-        </IconWrap>
-        <DateText>{post.updatedAt.substring(0, 10)}</DateText>
+      <WrapSection onClick={() => {
+        dispatch(AxiosDetail(url + `/post/${post.id}`));
+      }}>
+        <Link to='/postdetail'>
+          <PostText>{post.content}</PostText>
+          {images.map((image) => {
+            return (
+              <PostImg key={Math.random() * 100} src={"https://mandarin.api.weniv.co.kr/" + image} />
+            )
+          })}
+          <IconWrap>
+            <IconImg src={heartIcon} />
+            <IconImg src={messageIcon} />
+          </IconWrap>
+          <DateText>{post.updatedAt.substring(0, 10)}</DateText>
+        </Link>
       </WrapSection>
     </>
   )

--- a/src/components/post/feedPostStyle.js
+++ b/src/components/post/feedPostStyle.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { palette } from '../../style/globalColor';
 
-export const WrapperArticle = styled.article`
-width: 100%;
-`
+// export const WrapperArticle = styled.article`
+// width: 100%;
+// `
 
 export const WrapSection = styled.div`
 padding-left: 45px;
@@ -29,8 +29,8 @@ object-fit: cover;
 
 export const IconWrap = styled.div`
 text-align: left;
-display: inline-block;
-margin: 14px 0;
+display: block;
+padding: 14px 0;
 `
 
 export const IconImg = styled.img`

--- a/src/reducers/getPostDetailSlice.js
+++ b/src/reducers/getPostDetailSlice.js
@@ -1,34 +1,34 @@
-import {createSlice,createAsyncThunk,current } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk, current } from "@reduxjs/toolkit";
 import axios from 'axios';
 
 const initialState = {
-  detailData : [],
-  status : "idle",
+  detailData: [],
+  status: "idle",
   error: null
 }
 
 
 export const AxiosDetail = createAsyncThunk(
   'detailInfo/axiosDetail',
-  async(url) =>{
-    console.log("detail url?",url);
-    const token = JSON.parse(localStorage.getItem("token")) ;
+  async (url) => {
+    console.log("detail url?", url);
+    const token = JSON.parse(localStorage.getItem("token"));
     const config = {
       headers: {
-        "Authorization" : `Bearer ${token}`,
-        "Content-type" : "application/json"
+        "Authorization": `Bearer ${token}`,
+        "Content-type": "application/json"
       },
     }
-    const res = await axios(url,config);
-    console.log("res.data.product : ",res.data.product);
+    const res = await axios(url, config);
+    console.log("res.data.post : ", res.data.post);
     return res.data
   }
 )
 
 export const detailInfoSlice = createSlice({
-  name : "DetailInfo",
+  name: "DetailInfo",
   initialState,
-  reducers:{
+  reducers: {
   },
   extraReducers: (builder) => {
     builder
@@ -37,11 +37,11 @@ export const detailInfoSlice = createSlice({
         state.status = 'loading';
       })
       .addCase(AxiosDetail.fulfilled, (state, action) => {
-        console.log("성공",action);
+        console.log("성공", action);
         state.status = 'suceess';
         state.detailData = action.payload;
       })
-      .addCase(AxiosDetail.rejected,(state,action) => {
+      .addCase(AxiosDetail.rejected, (state, action) => {
         console.log("실패");
         state.state = 'fail';
       });
@@ -49,9 +49,9 @@ export const detailInfoSlice = createSlice({
 })
 
 console.log("디테일부분", detailInfoSlice);
-export const selectDetailPosts = (state) =>state.DetailInfo.detailData;
+export const selectDetailPosts = (state) => state.DetailInfo.detailData;
 export const detailPostsError = (state) => state.DetailInfo.error;
 export const detailPostStatus = (state) => state.DetailInfo.status;
 
-export default  detailInfoSlice.reducer;
+export default detailInfoSlice.reducer;
 export const detailActions = detailInfoSlice.actions;

--- a/src/template/postDetail/FeedPostDetail.jsx
+++ b/src/template/postDetail/FeedPostDetail.jsx
@@ -7,6 +7,7 @@ import FeedPost from '../../components/post/FeedPost'
 import { DetailWrapper } from './FeedPostDetailStyle';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectDetailPosts } from '../../reducers/getPostDetailSlice';
+import { SelectId } from '../../reducers/deletePostSlice'
 
 export default function FeedPostDetail() {
   const [userInfoList, setUserInfoList] = useState([]);
@@ -14,7 +15,7 @@ export default function FeedPostDetail() {
   const token = JSON.parse(localStorage.getItem("token"));
   const accountname = JSON.parse(localStorage.getItem("accountname"));
   const postDetail = useSelector(selectDetailPosts).post;
-  console.log(postDetail);
+  const currentPostId = useSelector(SelectId);
   
   useEffect(() => {
     getUserInfo();
@@ -42,7 +43,7 @@ export default function FeedPostDetail() {
       <ScrollMain>
         <DetailWrapper>
           {
-            postDetail && <FeedPost post={postDetail} />
+            postDetail.id === currentPostId && <FeedPost post={postDetail} />
           }
         </DetailWrapper>
       </ScrollMain>

--- a/src/template/postDetail/FeedPostDetail.jsx
+++ b/src/template/postDetail/FeedPostDetail.jsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
+import { AllWrap, ScrollMain } from '../../style/commonStyle'
+import { NavBack } from '../../components/navBack/NavBack'
+import Comment from '../../components/comment/Comment'
+import FeedPost from '../../components/post/FeedPost'
+import { DetailWrapper } from './FeedPostDetailStyle';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectDetailPosts } from '../../reducers/getPostDetailSlice';
+
+export default function FeedPostDetail() {
+  const [userInfoList, setUserInfoList] = useState([]);
+  const url = "https://mandarin.api.weniv.co.kr";
+  const token = JSON.parse(localStorage.getItem("token"));
+  const accountname = JSON.parse(localStorage.getItem("accountname"));
+  const postDetail = useSelector(selectDetailPosts).post;
+  console.log(postDetail);
+  
+  useEffect(() => {
+    getUserInfo();
+  }, [])
+
+  function getUserInfo() {
+    try {
+      axios.get(url + `/profile/${accountname}`, {
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-type": "application/json"
+        }
+      }).then((res) => setUserInfoList(res.data.profile))
+    }
+    catch (error) {
+      console.log(error);
+    }
+  }
+
+  return (
+    <AllWrap>
+      <header>
+        <NavBack />
+      </header>
+      <ScrollMain>
+        <DetailWrapper>
+          {
+            postDetail && <FeedPost post={postDetail} />
+          }
+        </DetailWrapper>
+      </ScrollMain>
+      <Comment img={url + `/${userInfoList.image}`}></Comment>
+    </AllWrap>
+  )
+}

--- a/src/template/postDetail/FeedPostDetailStyle.js
+++ b/src/template/postDetail/FeedPostDetailStyle.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+import { palette } from '../../style/globalColor'
+
+export const DetailWrapper = styled.div`
+  padding: 20px 11px 23px;
+  border-bottom: 1px solid ${palette.lightGray};
+`

--- a/src/template/profilePost/MyProfileSnsPost.jsx
+++ b/src/template/profilePost/MyProfileSnsPost.jsx
@@ -4,7 +4,7 @@ import listOff from '../../assets/icon-post-list-off.svg'
 import listOn from '../../assets/icon-post-list-on.svg'
 import albumOff from '../../assets/icon-post-album-off.svg'
 import albumOn from '../../assets/icon-post-album-on.svg'
-import { MySnsPost } from '../snsPost/SnsPost'
+import { SnsPost } from '../snsPost/SnsPost'
 import SnsAlbum from './SnsAlbum'
 
 function MyProfileSnsPost() {
@@ -29,7 +29,7 @@ function MyProfileSnsPost() {
             <ShowBtnStyle showIcon={albumOff}
               onClick={albumClick} />
           </ShowWrap>
-          <MySnsPost />
+          <SnsPost />
         </section>
         :
         <section>

--- a/src/template/snsFeed/SnsFeed.jsx
+++ b/src/template/snsFeed/SnsFeed.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { ScrollMain } from '../../style/commonStyle'
-import { FollowSnsPost } from '../snsPost/SnsPost'
+import { SnsPost } from '../snsPost/SnsPost'
 
 export default function SnsFeed() {
   return (
     <ScrollMain>
-      <FollowSnsPost />
+      <SnsPost />
     </ScrollMain>
   )
 }

--- a/src/template/snsPost/SnsPost.jsx
+++ b/src/template/snsPost/SnsPost.jsx
@@ -1,88 +1,33 @@
-import React, { useState } from 'react'
-import { useLocation } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react'
+import { useSelector } from 'react-redux';
 import { selectAllSnsPosts } from '../../reducers/getPostSlice.js'
-import { deleteActions } from '../../reducers/deletePostSlice'
-import Modal from '../../components/postModal/PostModal';
 import FeedPost from '../../components/post/FeedPost'
 
-export function FollowSnsPost() {  //내가 팔로우한 사람들 게시글 (피드쪽)
-  const snsPosts = useSelector(selectAllSnsPosts).posts;
-  console.log(snsPosts);
-  const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png";
-  const marketImg = "http://146.56.183.55:5050/Ellipse.png";
-
-  function imgCheck(post) {
-    if (post.author.image === marketImg) {
-      return defaultImg;
-    }
-    else {
-      return "https://mandarin.api.weniv.co.kr/" + post.author.image;
-    }
-  }
+export function SnsPost() { 
+  const followSnsPosts = useSelector(selectAllSnsPosts).posts;
+  const mySnsPosts = useSelector(selectAllSnsPosts).post;
+  console.log('followSnsPosts', followSnsPosts);
+  console.log('mySnsPosts', mySnsPosts);
 
   return (
     <ul>
-      {snsPosts && snsPosts.map((post) => {
+      {/* 내가 팔로우한 사람들 SNS 게시글 */}
+      {followSnsPosts && followSnsPosts.map((post) => {
         return (
           <li key={post.id} style={{ padding: "16px" }}>
-            <FeedPost post={post} imgCheck={imgCheck} />
+            <FeedPost post={post} />
+          </li>
+        )
+      })}
+      {/* 내 SNS 게시글 */}
+      {mySnsPosts && mySnsPosts.map((post) => {
+        return (
+          <li key={post.id} style={{ padding: "16px" }}>
+            <FeedPost post={post} />
           </li>
         )
       })}
     </ul>
-  )
-}
-
-
-export function MySnsPost() {  // 내 sns게시글
-  const location = useLocation();
-  const name = location.state?.userId;
-  console.log("name", name);
-  const dispatch = useDispatch();
-  const snsPosts = useSelector(selectAllSnsPosts).post;
-  const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png";
-  const marketImg = "http://146.56.183.55:5050/Ellipse.png";
-
-  //기본이미지체크함수
-  function imgCheck(post) {
-    if (post.author.image === marketImg) {
-      return defaultImg;
-    }
-    else {
-      return "https://mandarin.api.weniv.co.kr/" + post.author.image;
-    }
-  }
-
-  //모달
-  const list = { '삭제': '', '수정': '/snspostmodify' };
-  const alertTxt = ['삭제하시겠어요?', '삭제'];
-  const [modal, setModal] = useState(false);
-
-  const closeModal = () => {
-    setModal(false)
-  }
-
-  const handleId = (snsId) => {
-    dispatch(deleteActions.checkType("post"));
-    dispatch(deleteActions.selectId(snsId));
-    setModal(modal => !modal)
-  }
-
-  return (
-    <>
-      {
-        (modal === true) && (name === undefined) && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />}
-      <ul>
-        {snsPosts && snsPosts.map((post) => {
-          return (
-            <li key={post.id} style={{ padding: "16px" }}>
-              <FeedPost post={post} imgCheck={imgCheck} handleId={handleId} />
-            </li>
-          )
-        })}
-      </ul>
-    </>
   )
 }
 


### PR DESCRIPTION
<첫번째 커밋> 
* 게시글 컴포넌트(FeedPost.jsx) 수정, 이에 따라 SnsPost.jsx내부 함수2개 -> 1개로 축소
 * 상세페이지에 적용가능하도록  Comment컴포넌트와 스타일 수정
 *  getPostDetailSlice.js에 구현되어 있는 게시글 상세 API를 통해 각 게시글 상세페이지 랜더링
![dd](https://user-images.githubusercontent.com/97039896/180634339-5d7223c9-7acd-464d-a7ba-0b597be33b10.gif)

close #243 

<br><br>

<두번째 커밋>
* 현재 useSelector를 통해 getPostDetailSlice.js의 게시글 상세페이지 API에서 데이터를 받아오고 이를 postDetail에 저장하고 있는 로직임. 
* 여기서 postDetail은 랜더링에 필요한 props인데, 데이터가 갱신되는 속도 차이로 인해 
다른 게시글 상세페이지에서 이전에 들어갔던 게시글의 데이터가 처음에 랜더링 되는 문제를 수정하였음.
![ddd](https://user-images.githubusercontent.com/97039896/180634342-068dbc8f-bd70-4da5-9f53-62acb2c0d311.gif)

close #245 

