### PR TITLE
:bug: Modify : 계정 검색 결괏값 출력

### DIFF
--- a/src/components/errorMessage/errorStyle.js
+++ b/src/components/errorMessage/errorStyle.js
@@ -12,3 +12,9 @@ color: ${palette.textPoint};
 font-weight: 400;
 font-size: 12px;
 `
+export const SearchMessageStyle = styled.p`
+margin-top: 15px;
+color: ${palette.textPoint};
+font-weight: 400;
+font-size: 14px;
+`

--- a/src/template/search/AccountSearch.jsx
+++ b/src/template/search/AccountSearch.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import React, { useState } from 'react'
 import { useEffect } from 'react'
-import { CorrectMessageStyle } from '../../components/errorMessage/errorStyle'
+import { SearchMessageStyle } from '../../components/errorMessage/errorStyle'
 import { NavTxtSearch } from '../../components/navBack/NavBack'
 import TabMenu from '../../components/tabMenu/TabMenu'
 import { User } from '../../components/user/User'
@@ -43,25 +43,31 @@ function AccountSearch() {
       </header>
 
       <FollowMain>
-        {searchResult.map((user) => {
-          console.log(user.image)
-
-          return (
-            <Link 
-              key={user._id}
-              to='/userprofile' 
-              state={{ userId: user.accountname }}>
-              <User 
-                userName={user.username} 
-                userId={user.accountname} 
-                img={`https://mandarin.api.weniv.co.kr/${user.image}`} 
-                keyword={keyword}
-              />
-            </Link>
-          )
-        })}
-        {searchResult.length === 0 && keyword.length >= 1 && <CorrectMessageStyle>검색된 결과가 없습니다.</CorrectMessageStyle>}
+        {keyword.length === 0
+          ? 
+          // 입력된 keyword가 0이면 메시지 출력
+          <SearchMessageStyle>사용자 계정 또는 이름을 입력해 주세요.</SearchMessageStyle>
+          :
+          // 입력된 keyword가 있으면 결괏값 출력
+          searchResult.map((user) => {
+            console.log(user.image)
+            return (
+              <Link 
+                key={user._id}
+                to='/userprofile' 
+                state={{ userId: user.accountname }}>
+                <User 
+                  userName={user.username} 
+                  userId={user.accountname} 
+                  img={`https://mandarin.api.weniv.co.kr/${user.image}`} 
+                  keyword={keyword}
+                />
+              </Link>
+            )
+          })
+        }
         {/* 검색된 계정이 0개, 입력된 keyword가 1개 이상이면 출력 */}
+        {searchResult.length === 0 && keyword.length >= 1 && <SearchMessageStyle>검색된 결과가 없습니다.</SearchMessageStyle>}
       </FollowMain>
       <TabMenu />
     </AllWrap>


### PR DESCRIPTION
## 구현 사항

- 계정 검색 입력란에 값을 지워도 결괏값이 비어있지 않고 남아있는 것을 확인할 수 있었습니다.
- 검색 입력값이 비어있다면 `사용자 계정 또는 이름을 입력해 주세요.` 메시지를 출력하도록 수정하였습니다.

<br>

## 결과

![](https://velog.velcdn.com/images/nu11/post/c004b7c5-c402-4f35-b18f-da40b5068055/image.gif)

close #248 