### PR TITLE
✨ Feat : 산책(펫)게시글 상세페이지 구현 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import YourProfilePage from './pages/YourProfilePage';
 import ModifyPost from './template/postModify/PostModify';
 import ModifySnsPost from './template/snsPostModify/SnsPostModify';
 import FeedPostDetail from './template/postDetail/FeedPostDetail';
+import WalkingPostDetail from './template/postDetail/WalkingPostDetail';
 
 function App() {
   return (
@@ -42,7 +43,8 @@ function App() {
         <Route path='/postmodify' element={<PrivateRoute>< ModifyPost/></PrivateRoute>}></Route>
         <Route path='/snspost' element={<PrivateRoute><AddSnsPost /></PrivateRoute>}></Route>
         <Route path='/snspostmodify' element={<PrivateRoute><ModifySnsPost/></PrivateRoute>}></Route>
-        <Route path='/postdetail/:id' element={<PrivateRoute><FeedPostDetail/></PrivateRoute>}></Route>
+        <Route path='/snspostdetail/:id' element={<PrivateRoute><FeedPostDetail/></PrivateRoute>}></Route>
+        <Route path='/walkingpostdetail/:id' element={<PrivateRoute><WalkingPostDetail/></PrivateRoute>}></Route>
         <Route path='/chatpage' element={<PrivateRoute><ChatList /></PrivateRoute>}></Route>
         <Route path='/search' element={<PrivateRoute><AccountSearch /></PrivateRoute>}></Route>
         <Route path='/myfollow' element={<PrivateRoute><MyFollow /></PrivateRoute>}></Route>

--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -89,7 +89,7 @@ export default function FeedPost({ post }) {
     dispatch(deleteActions.selectId(postId));
     dispatch(AxiosDetail(url + `/post/${postId}`))
   }
- 
+
   return (
     <>
       {
@@ -98,9 +98,9 @@ export default function FeedPost({ post }) {
 
       <UserMore userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} onClick={() => handleId(post.id)} />
 
-      <WrapSection onClick={() => {handleOnClick(post.id)}}>
+      <WrapSection onClick={() => { handleOnClick(post.id) }}>
 
-        <Link to= {'/postdetail/'+ post.id} >
+        <Link to={'/snspostdetail/' + post.id} >
           <PostText>{post.content}</PostText>
           {images.map((image) => {
             return (

--- a/src/reducers/getPostDetailSlice.js
+++ b/src/reducers/getPostDetailSlice.js
@@ -25,6 +25,24 @@ export const AxiosDetail = createAsyncThunk(
   }
 )
 
+export const AxiosWalkingPostDetail = createAsyncThunk(
+  'detailInfo/axiosWalingPostDetail',
+  async (url) => {
+    console.log("walingpostdetail url?", url);
+    const token = JSON.parse(localStorage.getItem("token"));
+    const config = {
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-type": "application/json"
+      },
+    }
+    const res = await axios(url, config);
+    console.log("res.data.product : ", res.data.product);
+    return res.data
+  }
+)
+
+
 export const detailInfoSlice = createSlice({
   name: "DetailInfo",
   initialState,
@@ -33,23 +51,30 @@ export const detailInfoSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(AxiosDetail.pending, (state) => {
-        console.log("로드중");
+        console.log("sns상세페이지 로드중");
         state.status = 'loading';
       })
       .addCase(AxiosDetail.fulfilled, (state, action) => {
-        console.log("성공", action);
+        console.log("sns상세페이지 성공", action);
         state.status = 'suceess';
         state.detailData = action.payload;
       })
+      .addCase(AxiosWalkingPostDetail.fulfilled, (state, action) => {
+        console.log("pet 상세페이지 성공", action);
+        state.status = 'suceess';
+        state.walkingDetailData = action.payload;
+      })
       .addCase(AxiosDetail.rejected, (state, action) => {
-        console.log("실패");
+        console.log("sns상세페이지 실패");
         state.state = 'fail';
       });
   },
+
 })
 
 console.log("디테일부분", detailInfoSlice);
 export const selectDetailPosts = (state) => state.DetailInfo.detailData;
+export const selectWalkingPostDetail = (state) => state.DetailInfo.walkingDetailData;
 export const detailPostsError = (state) => state.DetailInfo.error;
 export const detailPostStatus = (state) => state.DetailInfo.status;
 

--- a/src/template/homePost/HomePost.jsx
+++ b/src/template/homePost/HomePost.jsx
@@ -1,37 +1,52 @@
 import React from 'react'
 import { ContentTxt, DateTxt, PetImg, PetInfoTxt, PostStyle, TextWrap, TitleTxt, TxtBox, WrapPost } from './homePostStyle'
 import { UserChat } from '../../components/user/User'
+import { Link } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { AxiosWalkingPostDetail } from '../../reducers/getPostDetailSlice';
+import { deleteActions } from '../../reducers/deletePostSlice'
+
 
 export default function HomePost({ followpost }) {
+  const dispatch = useDispatch();
   console.log("템플릿", followpost);
   const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png"
   const marketImg = "http://146.56.183.55:5050/Ellipse.png"
+  const URL = "https://mandarin.api.weniv.co.kr";
+  // const UserId = UserIdPath.pathname.slice(15,);
 
   function imgCheck(post) {
     if (post.author.image === marketImg) {
       return defaultImg;
     }
     else {
-      return "https://mandarin.api.weniv.co.kr/" + post.author.image;
+      return URL + "/" + post.author.image;
     }
   }
+
+  const handleOnClick = (postId) => {
+    dispatch(AxiosWalkingPostDetail(URL + `/product/detail/${postId}`));
+  }
+
   return (
     <ul >
       {followpost && followpost.map((post) => {
         return (
-          <PostStyle key={post._id}>
+          <PostStyle key={post._id} >
             <UserChat userName={post.author.username} userId={post.author.accountname} img={imgCheck(post)} />
-            <WrapPost>
-              <PetImg src={"https://mandarin.api.weniv.co.kr/" + post.itemImage}></PetImg>
-              <TextWrap>
-                <TitleTxt>{post.itemName}</TitleTxt>
-                <ContentTxt>{post.link}</ContentTxt>
-                <DateTxt>{post.updatedAt.substring(0, 10)}</DateTxt>
-              </TextWrap>
-            </WrapPost>
+            <Link to={'/walkingpostdetail/' + post._id} onClick={() => { handleOnClick(post._id) }}>
+              <WrapPost>
+                <PetImg src={URL + "/" + post.itemImage}></PetImg>
+                <TextWrap>
+                  <TitleTxt>{post.itemName}</TitleTxt>
+                  <ContentTxt>{post.link}</ContentTxt>
+                  <DateTxt>{post.updatedAt.substring(0, 10)}</DateTxt>
+                </TextWrap>
+              </WrapPost>
+            </Link>
           </PostStyle>
         )
       })}
-    </ul>
+    </ul >
   )
 }

--- a/src/template/postDetail/FeedPostDetail.jsx
+++ b/src/template/postDetail/FeedPostDetail.jsx
@@ -6,14 +6,14 @@ import Comment from '../../components/comment/Comment'
 import FeedPost from '../../components/post/FeedPost'
 import { DetailWrapper } from './FeedPostDetailStyle'
 import { useDispatch, useSelector } from 'react-redux'
-import { selectDetailPosts,AxiosDetail } from '../../reducers/getPostDetailSlice'
+import { selectDetailPosts, AxiosDetail } from '../../reducers/getPostDetailSlice'
 import CommentList from '../../components/commentList/CommentList'
 import { AxiosCommentList, getCommentList } from '../../reducers/getCommentSlice'
 import { useLocation } from "react-router-dom"
 
 export default function FeedPostDetail() {
   const UserIdPath = useLocation();
-  const UserId = UserIdPath.pathname.slice(12,);
+  const UserId = UserIdPath.pathname.slice(15,);
   const [userInfoList, setUserInfoList] = useState([]);
   const URL = "https://mandarin.api.weniv.co.kr";
   const token = JSON.parse(localStorage.getItem("token"));
@@ -21,14 +21,14 @@ export default function FeedPostDetail() {
   const postDetail = useSelector(selectDetailPosts).post;
   const commentList = useSelector(getCommentList).comments; //댓글리스트
   const dispatch = useDispatch();
-   
+
   useEffect(() => {
     getUserInfo();
-    dispatch(AxiosCommentList(URL+`/post/${UserId}/comments`)) 
-    dispatch(AxiosDetail(URL+`/post/${UserId}`))
+    dispatch(AxiosCommentList(URL + `/post/${UserId}/comments`))
+    dispatch(AxiosDetail(URL + `/post/${UserId}`))
   }, [])
 
-  
+
   function getUserInfo() {
     try {
       axios.get(URL + `/profile/${accountname}`, {
@@ -56,9 +56,9 @@ export default function FeedPostDetail() {
         </DetailWrapper>
         <ul>
           {
-            commentList?.map((comment)=>{
-              return(
-                <CommentList key={comment.id} content={comment.content} time={comment.createdAt} author={comment.author.accountname}   src = {comment.author.image} />
+            commentList?.map((comment) => {
+              return (
+                <CommentList key={comment.id} content={comment.content} time={comment.createdAt} author={comment.author.accountname} src={comment.author.image} />
               )
             })
           }

--- a/src/template/postDetail/WalkingPostDetail.jsx
+++ b/src/template/postDetail/WalkingPostDetail.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react'
+import { useLocation } from "react-router-dom"
+import { selectWalkingPostDetail, AxiosWalkingPostDetail } from '../../reducers/getPostDetailSlice'
+import { useSelector, useDispatch } from 'react-redux'
+import { palette } from '../../style/globalColor'
+import { AllWrap, ScrollMain } from '../../style/commonStyle'
+import { NavBack } from '../../components/navBack/NavBack'
+import { UserFollow } from '../../components/user/User'
+import { PostDetailWrapper, ContentWrapper, PetImg, TitleTxt, ContentTxt, DateTxt } from '../postDetail/walkingPostDetailStyle'
+import { Button } from '../../components/button/buttonStyle'
+
+export default function WalkingPostDetail() {
+  const dispatch = useDispatch();
+  const URL = "https://mandarin.api.weniv.co.kr";
+  const defaultImg = "https://mandarin.api.weniv.co.kr/1657812669741.png"
+  const marketImg = "http://146.56.183.55:5050/Ellipse.png"
+  const postDetail = useSelector(selectWalkingPostDetail)?.product;
+  const UserIdPath = useLocation();
+  const UserId = UserIdPath.pathname.slice(19,);
+
+  useEffect(() => {
+    dispatch(AxiosWalkingPostDetail(URL + `/product/detail/${UserId}`))
+  }, [])
+
+  function imgCheck(postDetail) {
+    if (postDetail.author.image === marketImg) {
+      return defaultImg;
+    }
+    else {
+      return URL + "/" + postDetail.author.image;
+    }
+  }
+
+  return (
+    <AllWrap>
+      <header>
+        <NavBack />
+      </header>
+      {
+        postDetail?.id === UserId &&
+        <ScrollMain>
+          <PostDetailWrapper>
+            <UserFollow userName={postDetail.author.username} userId={postDetail.author.accountname} img={imgCheck(postDetail)} />
+            <ContentWrapper>
+              <PetImg src={URL + "/" + postDetail.itemImage}></PetImg>
+              <TitleTxt>{postDetail.itemName}</TitleTxt>
+              <ContentTxt>{postDetail.link}</ContentTxt>
+              <DateTxt>{postDetail.updatedAt.substring(0, 10)}</DateTxt>
+              <Button color={palette.mainColor} backColor={palette.white} hover>연락하기</Button>
+            </ContentWrapper>
+          </PostDetailWrapper>
+        </ScrollMain>
+      }
+    </AllWrap>
+  )
+}

--- a/src/template/postDetail/walkingPostDetailStyle.js
+++ b/src/template/postDetail/walkingPostDetailStyle.js
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+import { palette } from "../../style/globalColor";
+
+export const PostDetailWrapper = styled.main`
+  padding: 20px 11px;
+`
+
+export const ContentWrapper = styled.div`
+  padding-left: 46px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  @media screen and (min-width:500px) {
+    gap: 25px;
+  }
+`
+
+export const PetImg = styled.img`
+  width: 100%;
+  margin-top: 14px;
+  border-radius: 10px;
+
+  @media screen and (min-width:500px) {
+    margin-top: 20px;
+  }
+`
+
+export const TitleTxt = styled.h2`
+  font-size: 20px;
+  color: ${palette.textPoint};
+
+  @media screen and (min-width:500px) {
+    font-size: 24px;
+  }
+`
+
+export const ContentTxt = styled.p`
+  font-size: 15px;
+  line-height: 19px;
+  word-break: keep-all;
+
+  @media screen and (min-width:500px) {
+    font-size: 18px;
+    line-height: 25px;
+  }
+`
+
+export const DateTxt = styled.small`
+  font-size: 10px;
+  color: ${palette.darkGray};
+  margin-bottom: 20px;
+
+  @media screen and (min-width:370px) {
+    font-size: 13px;
+  }
+  @media screen and (min-width:500px) {
+    font-size: 15px;
+    margin-bottom: 30px;
+  }
+`

--- a/src/template/postDetail/walkingPostDetailStyle.js
+++ b/src/template/postDetail/walkingPostDetailStyle.js
@@ -18,8 +18,12 @@ export const ContentWrapper = styled.div`
 
 export const PetImg = styled.img`
   width: 100%;
+  height: 230px;
   margin-top: 14px;
+  border: 1px solid ${palette.lightGray};
   border-radius: 10px;
+  box-sizing: border-box;
+  object-fit: cover;
 
   @media screen and (min-width:500px) {
     margin-top: 20px;

--- a/src/template/profilePost/PetPost.jsx
+++ b/src/template/profilePost/PetPost.jsx
@@ -1,45 +1,65 @@
-import React,{useState} from 'react'
+import React, { useState } from 'react'
 import { AnimalBox } from '../../components/animalBox/AnimalBox'
 import { selectAllPosts } from '../../reducers/getPetInfoSlice'
 import { useSelector, useDispatch } from 'react-redux'
 import { MiniPostTitle, MiniPostWrap, SectionAllWrap } from './petPostStyle'
 import Modal from '../../components/postModal/PostModal';
 import { deleteActions } from '../../reducers/deletePostSlice'
-import {useLocation} from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+import { SelectId } from '../../reducers/deletePostSlice'
+import { Link } from 'react-router-dom'
 
 export function PetPost() {
   const location = useLocation();
   const name = location.state?.userId;
   const dispatch = useDispatch();
   const posts = useSelector(selectAllPosts).product;
-  const list = {'삭제':'','수정':'/postmodify','산책피드로 가기':'/homepage'};
-  const alertTxt=['삭제하시겠어요?','삭제'];
+  const list = { '삭제': '', '수정': '/postmodify', '상세페이지로 가기': '' };
+  const alertTxt = ['삭제하시겠어요?', '삭제'];
   const [modal, setModal] = useState(false);
+  const postId = useSelector(SelectId);
 
   const closeModal = () => {
     setModal(false)
   }
+
   //id값을 store에 저장하는 오는 함수
-  const handleId = (petId)=>{
+  const handleId = (petId) => {
     dispatch(deleteActions.checkType("product"));
     dispatch(deleteActions.selectId(petId));
-    setModal(modal => !modal)
+    setModal(modal => !modal);
   }
 
   return (
     <SectionAllWrap>
       <MiniPostTitle>산책가까?</MiniPostTitle>
       {
-        (modal=== true )&&(name ===undefined)&&<Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />}
+        (modal === true) && (name === undefined) && (list['상세페이지로 가기'] = `/walkingpostdetail/${postId}`) && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />
+      }
+      {
+        (modal === true) && (name !== undefined)
+      }
       <MiniPostWrap>
-        {posts && posts.map((post) => {
-          return (
-            <AnimalBox key={post.id}
-              src={`https://mandarin.api.weniv.co.kr/${post.itemImage}`}
-              title={post.itemName} time={post.updatedAt.substring(0, 10)} onClick={() => handleId(post.id)} />
-          )
+        {
+          posts && posts.map((post) => {
+            return (
+              name === undefined
+                ?
+                <AnimalBox key={post.id}
+                  src={`https://mandarin.api.weniv.co.kr/${post.itemImage}`}
+                  title={post.itemName} time={post.updatedAt.substring(0, 10)} onClick={() => handleId(post.id)} />
+                :
+                <Link to={'/walkingpostdetail/' + post.id}>
+                  <AnimalBox key={post.id}
+                    src={`https://mandarin.api.weniv.co.kr/${post.itemImage}`}
+                    title={post.itemName} time={post.updatedAt.substring(0, 10)} onClick={() => handleId(post.id)} />
+                </Link>
+            )
+          })
         }
-        )}
+        {
+
+        }
       </MiniPostWrap>
     </SectionAllWrap>
   )


### PR DESCRIPTION
* 산책게시글 상세페이지 UI 및 게시글 데이터 랜더링 구현
* 산책게시글 상세페이지의 url주소와 헷갈리지않기 위해 피드게시글 상세페이지 url주소 구체적으로 변경
* myprofile에서 산책게시글 클릭시 모달이 뜨는데 모달3번째 리스트에 상세페이지로 이동할 수 있도록 구현
* yourprofile에서는 산책게시글 클릭시 바로 상세페이지로 이동할 수 있도록 설정

close #260 