### PR TITLE
✨ Add : 앨범형 게시글 클시 상세페이지로 이동

### DIFF
--- a/src/style/commonStyle.js
+++ b/src/style/commonStyle.js
@@ -11,25 +11,26 @@ export const AllWrap = styled.div`
   height:100%;
   max-width: 600px;
   max-height:  1200px;
-overflow: hidden;
+  overflow: hidden;
+  box-shadow: 0 0 10px ${palette.lightGray};
 `
 
 export const ScrollMain = styled.main`
-height: 100%;
-overflow: auto;
-box-sizing: border-box;
-padding: 50px 5px;
-::-webkit-scrollbar {
+  height: 100%;
+  overflow: auto;
+  box-sizing: border-box;
+  padding: 50px 5px;
+  ::-webkit-scrollbar {
     width: 7px;
-}
-::-webkit-scrollbar-track {
+    display: none;
+  }
+  ::-webkit-scrollbar-track {
     background-color: none;
-
-}
-::-webkit-scrollbar-thumb {
+  }
+  ::-webkit-scrollbar-thumb {
     background-color: ${palette.veryLigntGray};
     border-radius: 10px;
-}
+  }
 `
 
 export const PaddingMain = styled.main`
@@ -37,8 +38,8 @@ export const PaddingMain = styled.main`
   `
 
 export const Title = styled.h1`
-font-size: 24px;
-text-align: center;
+  font-size: 24px;
+  text-align: center;
 `
 
 export const FormStyle = styled.div`

--- a/src/style/globalStyle.js
+++ b/src/style/globalStyle.js
@@ -45,14 +45,13 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
-
 a {
   text-decoration: none;
+	:link,:visited { color: black;}
 }
-
 button{
 	all: unset; 
-        }
+}
 `;
 
 

--- a/src/template/profilePost/SnsAlbum.jsx
+++ b/src/template/profilePost/SnsAlbum.jsx
@@ -2,23 +2,25 @@ import React from 'react'
 import { AlbumImage, AlbumWrap } from './SnsAlbumStyle'
 import { selectAllSnsPosts } from '../../reducers/getPostSlice.js'
 import { useSelector } from 'react-redux';
-import test from '../../assets/rang.jpg'
+import { Link } from 'react-router-dom';
 
 export function SnsAlbum() {
   const snsPosts = useSelector(selectAllSnsPosts).post;
   console.log('sns', snsPosts)
+
   return (
     <AlbumWrap>
       {snsPosts && snsPosts.map((post) => {
         let postimg = post.image.split(",")
         console.log(postimg)
         return (
-          <AlbumImage key={post.id}
-            src={"https://mandarin.api.weniv.co.kr/" + postimg[0]}
-          />
+          <Link to={'/snspostdetail/' + post.id} key={post.id} >
+            <AlbumImage
+              src={"https://mandarin.api.weniv.co.kr/" + postimg[0]} />
+          </Link>
         )
       })}
-    </AlbumWrap>
+    </AlbumWrap >
   )
 }
 


### PR DESCRIPTION
1 commit
* myprofile과 yourprofile의 sns게시글에서 앨범형일 때 이미지 클릭시 해당 게시글의 상세페이지로 이동할 수 있도록 링크 연결 

<br>

2 commit
* 세로 스크롤로 인하여 랜더링될 때 레이아웃이 밀리는 현상이 있으므로 안보이도록 설정
* <Link>태그로 묶인 게시글들이 링크 태그의 속성때문에 이미 방문한 게시글의 텍스트는 보라색으로, 방문하지않은 게시글의 텍스트는 파란색으로 뜨는 부분이 없도록 속성 수정

<br><br>

close #274 