### PR TITLE
:lipstick: Style : Input 안쪽여백 추가

### DIFF
--- a/src/components/input/inputStyle.js
+++ b/src/components/input/inputStyle.js
@@ -4,6 +4,7 @@ import { palette } from '../../style/globalColor';
 export const InputStyle = styled.input`
 width: 100%;
 margin-top: 10px;
+padding-left: 4px;
 display: block;
 background-color: white;
 border: none; 
@@ -35,6 +36,7 @@ height: 50px;
 resize: none;
 width: 100%;
 margin-top: 10px;
+padding-left: 4px;
 display: block;
 background-color: white;
 border: none; 


### PR DESCRIPTION
## 구현
- 사용자 가독성을 위해 InputStyle, TextAreaStyle 스타일 컴포넌트에 `padding-left: 4px` 추가했습니다.

<br>

## 구현 전

![image](https://user-images.githubusercontent.com/100080663/181075372-a3012996-3409-43f0-9d5b-f1172925f19e.png)
  
<br>

![image](https://user-images.githubusercontent.com/100080663/181075707-01d4483d-f7d6-4cab-8676-482e2dbbb3bc.png)

<br>

![image](https://user-images.githubusercontent.com/100080663/181075720-de94f9c4-101b-4838-93d8-827c3779d2b8.png)




## 구현 후

![image](https://user-images.githubusercontent.com/100080663/181075282-5f7e1c8a-264b-4417-9d4a-4b78b40e5309.png)

<br>

![image](https://user-images.githubusercontent.com/100080663/181076197-61b3fa28-417d-476c-aca9-daf5889d3ed9.png)

<br>

![image](https://user-images.githubusercontent.com/100080663/181076230-3e4c0f97-6664-4591-8674-b9117d83a7a9.png)


close #276 