### PR TITLE
Feat/수정페이지새로고침버그

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,9 +41,9 @@ function App() {
         <Route path='/profilepage' element={<PrivateRoute><MyProfilePage /></PrivateRoute>}></Route>
         <Route path='/profilemodify' element={<PrivateRoute><ProfileModify /></PrivateRoute>}></Route>
         <Route path='/post' element={<PrivateRoute><AddPost /></PrivateRoute>}></Route>
-        <Route path='/postmodify' element={<PrivateRoute>< ModifyPost /></PrivateRoute>}></Route>
+        <Route path='/postmodify/:id' element={<PrivateRoute>< ModifyPost /></PrivateRoute>}></Route>
         <Route path='/snspost' element={<PrivateRoute><AddSnsPost /></PrivateRoute>}></Route>
-        <Route path='/snspostmodify' element={<PrivateRoute><ModifySnsPost /></PrivateRoute>}></Route>
+        <Route path='/snspostmodify/:id' element={<PrivateRoute><ModifySnsPost /></PrivateRoute>}></Route>
         <Route path='/snspostdetail/:id' element={<PrivateRoute><FeedPostDetail /></PrivateRoute>}></Route>
         <Route path='/walkingpostdetail/:id' element={<PrivateRoute><WalkingPostDetail /></PrivateRoute>}></Route>
         <Route path='/chatpage' element={<PrivateRoute><ChatList /></PrivateRoute>}></Route>

--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -54,7 +54,7 @@ function FeedPost({ post }) {
   }
 
   //모달
-  const list = { '삭제': '', '수정': '/snspostmodify' };
+  const list = { '삭제': '', '수정': `/snspostmodify/${post.id}` };
   const alertTxt = ['삭제하시겠어요?', '삭제'];
   const [modal, setModal] = useState(false);
 

--- a/src/template/postModify/PostModify.jsx
+++ b/src/template/postModify/PostModify.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useDispatch, useSelector } from "react-redux";
-import { SelectId } from '../../reducers/deletePostSlice'
+import { useLocation } from "react-router-dom"
 import { AxiosDetail, selectDetailPosts } from '../../reducers/getPostDetailSlice'
 import { AxiosPetInfo } from '../../reducers/getPetInfoSlice'
 import axios from 'axios';
@@ -14,7 +14,8 @@ import { ImgUpload } from '../../pages/SignUpMain';
 export default function ModifyPost() {
 
   const dispatch = useDispatch();
-  const selectId = useSelector(SelectId);
+  const UserIdPath = useLocation();
+  const selectId = UserIdPath.pathname.slice(12,);
   const URL = "https://mandarin.api.weniv.co.kr";
 
   //기존 게시글정보

--- a/src/template/profilePost/PetPost.jsx
+++ b/src/template/profilePost/PetPost.jsx
@@ -16,11 +16,10 @@ export function PetPost() {
   const name = location.state?.userId;
   const dispatch = useDispatch();
   const posts = useSelector(selectAllPosts).product;
-  const list = { '삭제': '', '수정': '/postmodify', '상세페이지로 가기': '' };
   const alertTxt = ['삭제하시겠어요?', '삭제'];
   const [modal, setModal] = useState(false);
   const postId = useSelector(SelectId);
-
+  const list = { '삭제': '', '수정': `/postmodify/${postId}`, '상세페이지로 가기': `/walkingpostdetail/${postId}` };
   const closeModal = () => {
     setModal(false)
   }
@@ -44,7 +43,7 @@ export function PetPost() {
     <SectionAllWrap>
       <MiniPostTitle>산책가까?</MiniPostTitle>
       {
-        (modal === true) && (name === undefined) && (list['상세페이지로 가기'] = `/walkingpostdetail/${postId}`) && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />
+        (modal === true) && (name === undefined) && <Modal list={list} alertTxt={alertTxt} closeModal={closeModal} setModal={setModal} />
       }
       <MiniPostWrap>
         {

--- a/src/template/snsPostModify/SnsPostModify.jsx
+++ b/src/template/snsPostModify/SnsPostModify.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useLayoutEffect, useEffect } from 'react'
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom"
 import { AxiosPost } from '../../reducers/getPostSlice';
-import { SelectId } from '../../reducers/deletePostSlice';
 import { AxiosDetail, selectDetailPosts } from '../../reducers/getPostDetailSlice'
 import axios from 'axios'
 
@@ -13,7 +13,9 @@ import { ImgUpload } from '../../pages/SignUpMain'
 
 export default function ModifySnsPost() {
   const dispatch = useDispatch();
-  const selectId = useSelector(SelectId);
+  const UserIdPath = useLocation();
+  const selectId = UserIdPath.pathname.slice(15,);
+
   const URL = "https://mandarin.api.weniv.co.kr";
   //선택한게시글
   const detailPostData = useSelector(selectDetailPosts).post;


### PR DESCRIPTION
- pet게시글과 sns게시글 수정페이지에서 새로고침시 id값이 날라가 data를 렌더링 하지 못하는 오류가 있었습니다.
- 디테일 페이지와 동일하게 URL에 `/:id`를 주어 해결했습니다. 