### PR TITLE
Feat/UI디테일수정

### DIFF
--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, memo } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { deleteActions } from '../../reducers/deletePostSlice'
 import { UserMore } from '../user/User.jsx'
-import { WrapSection, PostText, PostImg, DateText, IconWrap, IconImg } from './feedPostStyle'
+import { WrapSection, PostText, PostImg, DateText, IconWrap, IconImg, PostImgWrap } from './feedPostStyle'
 import emptyheartIcon from '../../assets/icon-heart.svg'
 import heartIcon from '../../assets/icon-heart-fill.svg'
 import messageIcon from '../../assets/icon-message.svg'
@@ -88,7 +88,7 @@ function FeedPost({ post }) {
     }
   }
   let keyVal = 1;
-  
+
   return (
     <>
       {
@@ -99,20 +99,21 @@ function FeedPost({ post }) {
       <WrapSection onClick={() => { handleOnClick(post.id) }}>
         <Link to={'/snspostdetail/' + post.id} >
           <PostText>{post.content}</PostText>
-          {
-            images?.map((image) => {
-              if (image) {
-                return (
-                  (image?.search(URL) !== -1 || image?.search('base64') !== -1 || image?.search('.svg') !== -1)
-                    ?
-
-                    <PostImg key ={keyVal++} src={image} alt="게시글 이미지"  />
-                    :
-                    <PostImg  key ={keyVal++} src={`${URL}/${image}`} alt="게시글 이미지" />
-                )
-              }
-            })
-          }
+          <PostImgWrap>
+            {
+              images?.map((image) => {
+                if (image) {
+                  return (
+                    (image?.search(URL) !== -1 || image?.search('base64') !== -1 || image?.search('.svg') !== -1)
+                      ?
+                      <PostImg key={keyVal++} src={image} alt="게시글 이미지" />
+                      :
+                      <PostImg key={keyVal++} src={`${URL}/${image}`} alt="게시글 이미지" />
+                  )
+                }
+              })
+            }
+          </PostImgWrap>
         </Link>
         <IconWrap>
           <button onClick={handlesetLike} style={{ cursor: 'pointer' }}>

--- a/src/components/post/feedPostStyle.js
+++ b/src/components/post/feedPostStyle.js
@@ -17,6 +17,25 @@ word-break: keep-all;
 white-space: pre-wrap;
 margin:14px 0;  
 `
+export const PostImgWrap = styled.div`
+display: flex;
+flex-direction: row;
+gap: 10px;
+overflow: auto;
+padding-bottom: 10px;
+
+::-webkit-scrollbar {
+    height: 7px;
+}
+::-webkit-scrollbar-track {
+    background-color: none;
+}
+::-webkit-scrollbar-thumb {
+    background-color: #EdEded;
+    border-radius: 10px;
+}
+`
+
 
 export const PostImg = styled.img`
 width: 100%;
@@ -25,6 +44,7 @@ border: 1px solid ${palette.lightGray};
 border-radius: 10px;
 box-sizing: border-box;
 object-fit: cover;
+flex-shrink: 0;
 
 @media screen and (min-width: 600px) {
   height: 370px;

--- a/src/components/post/feedPostStyle.js
+++ b/src/components/post/feedPostStyle.js
@@ -25,6 +25,14 @@ border: 1px solid ${palette.lightGray};
 border-radius: 10px;
 box-sizing: border-box;
 object-fit: cover;
+
+@media screen and (min-width: 600px) {
+  height: 370px;
+}
+
+@media screen and (min-width: 450px) and (max-width : 600px) {
+  height: 300px;
+}
 `
 
 export const IconWrap = styled.div`

--- a/src/pages/FeedPage.jsx
+++ b/src/pages/FeedPage.jsx
@@ -18,7 +18,7 @@ export default function FeedPage() {
 
   useEffect(() => {
     if (status === 'idle') {
-      dispatch(AxiosFeedPost(URL + "/post/feed"))
+      dispatch(AxiosFeedPost(URL + "/post/feed/?limit=30"))
     }
   }, [status])
 

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -13,7 +13,6 @@ import MyProfileSnsPost from '../template/profilePost/MyProfileSnsPost'
 
 function MyProfilePage() {
   const dispatch = useDispatch();
-  const postsStatus = useSelector(getPostStatus);
   //펫등록 게시글 수 
   const postLength = useSelector(selectAllPosts).product?.length;
   //sns게시글 수
@@ -25,7 +24,7 @@ function MyProfilePage() {
 
   useEffect(() => {
     dispatch(AxiosPetInfo(URL + ReqPath))
-    dispatch(AxiosPost(URL + "/post/" + accountname + "/userpost"))
+    dispatch(AxiosPost(URL + "/post/" + accountname + "/userpost/?limit=30"))
   }, [dispatch])
 
   return (

--- a/src/template/homePost/homePostStyle.js
+++ b/src/template/homePost/homePostStyle.js
@@ -13,6 +13,11 @@ export const PostStyle = styled.li`
   :last-child {
     border-bottom: none;
   }
+
+  @media screen and (min-width: 470px) {
+  height: 235px;
+}
+
 `
 
 export const PetImg = styled.img`
@@ -20,16 +25,29 @@ export const PetImg = styled.img`
   height: 120px;
   border-radius: 10px;
   border: 1px solid ${palette.lightGray};
-  object-fit: cover;  
+  object-fit: cover;
+  flex-shrink: 0;
+
+  @media screen and (min-width: 470px) {
+    width: 150px;
+  height: 150px;
+}
 `
 
 export const TitleTxt = styled.p`
   font-size: 17px;
   line-height: 20px;
+  margin-top: 5px ;
   color: ${palette.textPoint};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+@media screen and (min-width: 470px) {
+  font-size: 22px;
+  line-height: 27px;
+  margin-top: 10px ;
+}
+
 `
 
 export const ContentTxt = styled.p`
@@ -41,13 +59,21 @@ export const ContentTxt = styled.p`
   font-size: 14px;
   line-height: 17px;
   word-break: keep-all;
+  @media screen and (min-width: 470px) {
+  font-size: 18px;
+  line-height: 27px;
+}
 `
 
 export const DateTxt = styled.p`
   font-size: 10px;
-  line-height: 12px;
+  line-height: 14px;
   color: ${palette.darkGray};
   margin-bottom: 5px;
+  @media screen and (min-width: 470px) {
+  font-size: 13px;
+  line-height: 16px;
+}
 `
 export const WrapPost = styled.div`
 display: flex;


### PR DESCRIPTION
- sns 피드 게시글 이미지 사이즈 반응형으로 변경
- 게시글 사진 여러장 등록됐을경우 아래로 이미지가 떨어지는 방식을 row정렬로  스크롤 할 수 있도록 변경했습니다
![이미지](https://user-images.githubusercontent.com/54096506/181635664-7ba51f87-33c4-463b-b4e8-5ed829f391c4.gif)
- 기존에 홈피드에서 특정이미지만 UI가 찌그러지는 현상이 있어 해결하였습니다
![image](https://user-images.githubusercontent.com/54096506/181635770-e588b389-5745-469d-89dc-4c19df7061e4.png)
(변경전)
![image](https://user-images.githubusercontent.com/54096506/181635738-187401b5-eb46-4e0e-8a98-4a4c65a4b3a5.png)
(변경후)
-홈피드 또한 반응형으로 이미지와 글자 크기 조절하였습니다
