### PR TITLE
:lipstick: Modify : 홈페이지, 피드페이지에서 게시글에 말줄임표 적용

### DIFF
--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -19,6 +19,7 @@ function FeedPost({ post }) {
   const images = post.image?.split(",");
   const [isLike, setIsLike] = useState("");
   const [heartCount, setheartCount] = useState("");
+  const linkName = useLocation().pathname.slice(1, 14);
 
   useEffect(() => {
     setIsLike(post.hearted)
@@ -98,7 +99,7 @@ function FeedPost({ post }) {
 
       <WrapSection onClick={() => { handleOnClick(post.id) }}>
         <Link to={'/snspostdetail/' + post.id} >
-          <PostText>{post.content}</PostText>
+          <PostText linkName={linkName}>{post.content}</PostText>
           <PostImgWrap>
             {
               images?.map((image) => {

--- a/src/components/post/feedPostStyle.js
+++ b/src/components/post/feedPostStyle.js
@@ -1,21 +1,29 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { palette } from '../../style/globalColor';
-
-// export const WrapperArticle = styled.article`
-// width: 100%;
-// `
 
 export const WrapSection = styled.div`
 padding-left: 45px;
 `
 
 export const PostText = styled.p`
-font-size: 14px;
-line-height: 17px;
-text-align: left;
-word-break: keep-all;
-white-space: pre-wrap;
-margin:14px 0;  
+  font-size: 14px;
+  line-height: 17px;
+  text-align: left;
+  margin: 14px 0;  
+  word-wrap: break-word;
+  word-break: keep-all;
+  white-space: pre-wrap;
+
+  ${({ linkName }) => {
+    if (linkName !== 'snspostdetail') {
+      return css`
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+    `}
+  }}
 `
 export const PostImgWrap = styled.div`
 display: flex;
@@ -35,7 +43,6 @@ padding-bottom: 10px;
     border-radius: 10px;
 }
 `
-
 
 export const PostImg = styled.img`
 width: 100%;

--- a/src/components/user/userStyle.js
+++ b/src/components/user/userStyle.js
@@ -29,6 +29,9 @@ export const UserName = styled.p`
   line-height: 17px;
   color: ${palette.textDark};
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 export const UserId = styled.p`
@@ -36,6 +39,9 @@ export const UserId = styled.p`
   line-height: 14px;
   color: ${palette.textDark};
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 export const MoreIcon = styled.img`

--- a/src/template/homePost/homePostStyle.js
+++ b/src/template/homePost/homePostStyle.js
@@ -17,7 +17,6 @@ export const PostStyle = styled.li`
   @media screen and (min-width: 500px) {
   height: 235px;
 }
-
 `
 
 export const PetImg = styled.img`
@@ -42,23 +41,26 @@ export const TitleTxt = styled.p`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  
 @media screen and (min-width: 500px) {
   font-size: 20px;
   line-height: 23px;
   margin-top: 10px ;
 }
-
 `
 
 export const ContentTxt = styled.p`
+  font-size: 14px;
+  line-height: 17px;
+  word-wrap: break-word;
+  word-break: keep-all;
+  white-space: pre-wrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  font-size: 14px;
-  line-height: 17px;
-  word-break: keep-all;
+  
   @media screen and (min-width: 500px) {
   font-size: 16px;
   line-height: 20px;

--- a/src/template/postDetail/walkingPostDetailStyle.js
+++ b/src/template/postDetail/walkingPostDetailStyle.js
@@ -34,6 +34,9 @@ export const PetImg = styled.img`
 export const TitleTxt = styled.h2`
   font-size: 20px;
   color: ${palette.textPoint};
+  word-wrap: break-word;
+  word-break: keep-all;
+  white-space: pre-wrap;
 
   @media screen and (min-width:500px) {
     font-size: 22px;
@@ -43,7 +46,9 @@ export const TitleTxt = styled.h2`
 export const ContentTxt = styled.p`
   font-size: 15px;
   line-height: 19px;
+  word-wrap: break-word;
   word-break: keep-all;
+  white-space: pre-wrap;
 
   @media screen and (min-width:500px) {
     font-size: 18px;

--- a/src/template/profile/ProfileStyle.js
+++ b/src/template/profile/ProfileStyle.js
@@ -40,8 +40,14 @@ export const IntroText = styled.p`
 font-size: 14px;
 line-height: 17px;
 color: ${palette.darkGray};
-margin-top: 12px;
-color: ${palette.darkGray};
+margin: 12px 96px 0;
+word-wrap: break-word;
+word-break: keep-all;
+overflow: hidden;
+text-overflow: ellipsis;
+display: -webkit-box;
+-webkit-line-clamp: 3;
+-webkit-box-orient: vertical;
 `
 export const ButtonWrap = styled.div`
 display: flex;


### PR DESCRIPTION
* 홈페이지, 피드페이지에서의 게시글에서는 텍스트가 길 경우 최대 3줄까지만 보이고 나머지는 말줄임표로 표시되도록 구현
* 상세페이지에서도 보기 편하도록 각 말줄임표 속성 적용
* 프로필에서 사용자 이름 및 소개 부분에서 과하게 길 경우를 방지하여 말 줄임표 적용
* 유저 정보가 보이는 NavBack에서 사용자 이름이 길 경우 말줄임표 적용

![ㅈㅂㅈㅈㅈ](https://user-images.githubusercontent.com/97039896/181742336-d005c1b7-78c1-4b16-aaf1-5e3388cac8f4.png)

close #327 