### PR TITLE
:bug: Modify : 로그인한 사용자 자신을 검색하여 클릭했을때, myprofile로 넘어가도록 라우팅 설정

### DIFF
--- a/src/template/search/AccountSearch.jsx
+++ b/src/template/search/AccountSearch.jsx
@@ -11,6 +11,7 @@ import { FollowMain } from '../follow/followStyle'
 function AccountSearch() {
   const [searchResult, setSearchResult] = useState([])
   const [keyword, setKeyword] = useState('')
+  const accountname = JSON.parse(localStorage.getItem("accountname"));
 
   useEffect(() => {
     if (keyword) {
@@ -50,11 +51,12 @@ function AccountSearch() {
           :
           // 입력된 keyword가 있으면 결괏값 출력
           searchResult.map((user) => {
-            console.log(user.image)
+            let linkName='';
+            accountname === user.accountname ? linkName='/profilepage': linkName='/userprofile';
             return (
               <Link
                 key={user._id}
-                to='/userprofile'
+                to={linkName}
                 state={{ userId: user.accountname }}>
                 <User
                   userName={user.username}


### PR DESCRIPTION
* 계정검색에서 자기 자신을 검색해서 클릭했을 때는 myprofile로 넘어가도록 삼항연산자를 추가

![dddd](https://user-images.githubusercontent.com/97039896/181934813-02ea6d92-012f-4132-880f-a74439607e0a.gif)
(동영상 밑에 있는 탭에서 프로필로 넘어가는 것을 확인할 수 있음)

close #365 
