### PR TITLE
:sparkles: Add : 댓글클릭시 유저프로필 페이지로 이동하도록 라우팅 설정

### DIFF
--- a/src/components/commentList/CommentList.jsx
+++ b/src/components/commentList/CommentList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom';
 import { ProfileIconS } from '../profileIcon/ProfileIcon'
 import moment from 'moment';
 import "moment/locale/ko";
@@ -6,18 +7,23 @@ import dot from '../../assets/icon-more-vertical.svg'
 import { CommentWrpper, Name, WritingTime, Content, UserMore } from './commentListStlye';
 
 export default function CommentList({ content, time, author, img, onClick }) {
+  const accountname = JSON.parse(localStorage.getItem("accountname"));
+  let linkName = '';
+  accountname === author ? linkName = '/profilepage' : linkName = '/userprofile';
 
   return (
     <li style={{ margin: "20px 16px" }}>
-      <CommentWrpper >
-        <ProfileIconS img={img} alt={"프로필 사진"} />
-        <Name>{author}</Name>
-        <WritingTime>· {moment(time).fromNow()}</WritingTime>
+      <CommentWrpper>
+        <Link to={linkName} state={{ userId: author }} style={{ display: "flex" }}>
+          <ProfileIconS img={img} alt={"프로필 사진"} />
+          <Name>{author}</Name>
+          <WritingTime>· {moment(time).fromNow()}</WritingTime>
+        </Link>
         <button style={{ marginLeft: "auto" }}>
           <UserMore src={dot} onClick={onClick} alt="댓글설정 버튼" />
         </button>
       </CommentWrpper>
       <Content>{content}</Content>
-    </li>
+    </li >
   )
 }

--- a/src/components/commentList/commentListStlye.js
+++ b/src/components/commentList/commentListStlye.js
@@ -4,19 +4,18 @@ import { palette } from '../../style/globalColor';
 export const CommentWrpper = styled.div`
   display:flex;
 `
+
 export const Name = styled.strong`
-  position:relative;
-  vertical-align: top;
   margin: 6px 6px 0 12px;
   font-size: 14px;
   font-weight: 400;
 `
+
 export const WritingTime = styled.strong`
   font-size: 10px;
   font-weight: 400;
   color : ${palette.darkGray};
-  position:relative;
-  margin-top:8.5px;  
+  margin-top: 8.5px;  
 `
 
 export const Content = styled.p`


### PR DESCRIPTION
* SNS게시글 상세페이지에 존재하는 댓글의 프로필정보를 클릭하면 해당 사용자의 프로필페이지로 이동할 수 있도록 구현

close #370 