### PR TITLE
Feat : 댓글,게시글 신고하기 기능 & 상세페이지에서 내 게시글 삭제 기능 구현

### DIFF
--- a/src/components/deleteAlert/DeleteAlert.jsx
+++ b/src/components/deleteAlert/DeleteAlert.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { DeleteType, AxiosDeletePost, SelectId } from '../../reducers/deletePostSlice'
+import { ReportType, AxiosReportPost, ReportId } from '../../reducers/reportPostSlice'
 import { selectCommentId, AxiosCommentList } from '../../reducers/getCommentSlice'
 import { AxiosDetail } from '../../reducers/getPostDetailSlice'
 import { AxiosPetInfo } from '../../reducers/getPetInfoSlice'
@@ -23,16 +24,22 @@ export function DeleteAlert({ mainTxt, rightBtnTxt, closeAlert, setModal }) {
   }
 
   const commentId = useSelector(selectCommentId);
-  const postId = location.pathname.slice(15, );
+  const postId = location.pathname.slice(15,);
 
   function handleDeleteBtn() {
     const URL = "https://mandarin.api.weniv.co.kr";
     // 댓글삭제
-    if (curPath === '/snspostdetail/') {
+    if (curPath === '/snspostdetail/' && rightBtnTxt === '삭제') {
       dispatch(AxiosDeletePost(URL + `/post/${postId}/comments/${commentId}`))
         .then(() => dispatch(AxiosCommentList(URL + `/post/${postId}/comments`)))
-        .then(() => dispatch(AxiosDetail(URL + `/post/${postId}`)) );
+        .then(() => dispatch(AxiosDetail(URL + `/post/${postId}`)));
       setModal(false);
+    }
+    //댓글신고
+    else if (curPath === '/snspostdetail/' && rightBtnTxt === '신고') {
+      dispatch(AxiosReportPost(URL + `/post/${postId}/comments/${commentId}/report`))
+      setModal(false);
+      window.alert("해당 댓글이 신고되었습니다.");
     }
     //내 pet,sns게시글 삭제
     else {

--- a/src/components/deleteAlert/DeleteAlert.jsx
+++ b/src/components/deleteAlert/DeleteAlert.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { DeleteType, AxiosDeletePost, SelectId } from '../../reducers/deletePostSlice'
-import { ReportType, AxiosReportPost, ReportId } from '../../reducers/reportPostSlice'
+import { AxiosReportPost } from '../../reducers/reportPostSlice'
 import { selectCommentId, AxiosCommentList } from '../../reducers/getCommentSlice'
 import { AxiosDetail } from '../../reducers/getPostDetailSlice'
 import { AxiosPetInfo } from '../../reducers/getPetInfoSlice'
@@ -10,12 +10,15 @@ import { AxiosPost } from '../../reducers/getPostSlice'
 import { AlertOver, AlertWrapper, DeleteTxt, DeleteAlertBtn } from './deleteStyle'
 
 export function DeleteAlert({ mainTxt, rightBtnTxt, closeAlert, setModal }) {
+  const navigator = useNavigate();
+  const location = useLocation();
   const dispatch = useDispatch();
   const postType = useSelector(DeleteType);
   const Id = useSelector(SelectId);
+  const commentId = useSelector(selectCommentId);
   const accountname = JSON.parse(localStorage.getItem("accountname"));
-  const location = useLocation();
-  const curPath = location.pathname.slice(0, 15);
+  const curPath = location.pathname.slice(0, 14);
+  const postId = location.pathname.slice(15,);
 
   // 로그아웃함수
   const removeInfo = () => {
@@ -23,32 +26,35 @@ export function DeleteAlert({ mainTxt, rightBtnTxt, closeAlert, setModal }) {
     window.localStorage.removeItem("accountname");
   }
 
-  const commentId = useSelector(selectCommentId);
-  const postId = location.pathname.slice(15,);
-
   function handleDeleteBtn() {
     const URL = "https://mandarin.api.weniv.co.kr";
-    // 댓글삭제
-    if (curPath === '/snspostdetail/' && rightBtnTxt === '삭제') {
+    // 내 댓글 삭제
+    if (postType === 'comments' && rightBtnTxt === '삭제') {
       dispatch(AxiosDeletePost(URL + `/post/${postId}/comments/${commentId}`))
         .then(() => dispatch(AxiosCommentList(URL + `/post/${postId}/comments`)))
         .then(() => dispatch(AxiosDetail(URL + `/post/${postId}`)));
-      setModal(false);
     }
-    //댓글신고
-    else if (curPath === '/snspostdetail/' && rightBtnTxt === '신고') {
-      dispatch(AxiosReportPost(URL + `/post/${postId}/comments/${commentId}/report`))
-      setModal(false);
+    // 댓글 신고
+    else if (postType === 'comments' && rightBtnTxt === '신고') {
+      dispatch(AxiosReportPost(URL + `/post/${postId}/comments/${commentId}/report`));
       window.alert("해당 댓글이 신고되었습니다.");
     }
-    //내 pet,sns게시글 삭제
+    // 게시글 신고
+    else if (postType === 'post' && rightBtnTxt === '신고') {
+      dispatch(AxiosReportPost(URL + `/post/${Id}/report`));
+      window.alert("해당 게시글이 신고되었습니다.");
+    }
+    // 내 pet, sns게시글 삭제
     else {
-      const ReqPath = `/${postType}/${Id}`;
-      dispatch(AxiosDeletePost(URL + ReqPath))
+      dispatch(AxiosDeletePost(URL + `/${postType}/${Id}`))
         .then(() => postType === 'product' && dispatch(AxiosPetInfo(URL + `/product/${accountname}`)))
         .then(() => postType === 'post' && dispatch((AxiosPost(URL + `/post/${accountname}/userpost`))));
-      setModal(false);
+
+      if (curPath === '/snspostdetail') {
+        navigator('/profilepage');
+      }
     }
+    setModal(false);
   }
 
   return (

--- a/src/components/post/FeedPost.jsx
+++ b/src/components/post/FeedPost.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, memo } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { Link, useLocation } from 'react-router-dom'
 import { deleteActions } from '../../reducers/deletePostSlice'
 import { AxiosDetail } from '../../reducers/getPostDetailSlice'
@@ -16,10 +16,12 @@ function FeedPost({ post }) {
   const dispatch = useDispatch();
   const MyId = JSON.parse(localStorage.getItem('accountname'));
   const URL = 'https://mandarin.api.weniv.co.kr';
+  const curPath = useLocation().pathname;
+  const linkName = useLocation().pathname.slice(1, 14);
   const images = post.image?.split(',');
   const [isLike, setIsLike] = useState('');
   const [heartCount, setheartCount] = useState('');
-  const linkName = useLocation().pathname.slice(1, 14);
+  const [modal, setModal] = useState(false);
 
   useEffect(() => {
     dispatch(AxiosFeedPost(URL + '/post/feed/?limit=30'));
@@ -31,9 +33,15 @@ function FeedPost({ post }) {
   }, [post]);
 
   //모달
-  const list = { '삭제': '', '수정': `/snspostmodify/${post.id}` };
-  const alertTxt = ['삭제하시겠어요?', '삭제'];
-  const [modal, setModal] = useState(false);
+  let list = [];
+  let alertTxt = [];
+  if (curPath === "/profilepage" || MyId === post.author.accountname) {
+    list = { '삭제': '', '수정': `/snspostmodify/${post.id}` };
+    alertTxt = ['삭제하시겠어요?', '삭제'];
+  } else {
+    list = { '신고하기': '' };
+    alertTxt = ['신고하시겠어요?', '신고'];
+  }
 
   const closeModal = () => {
     setModal(false);
@@ -44,7 +52,6 @@ function FeedPost({ post }) {
     dispatch(deleteActions.selectId(snsId));
     setModal(modal => !modal);
   }
-
 
   // 좋아요 버튼 함수
   const handlesetLike = () => {
@@ -64,7 +71,6 @@ function FeedPost({ post }) {
     }
   }
 
-
   const location = useLocation();
   const handleOnClick = (postId) => {
     const path = location.pathname;
@@ -78,7 +84,7 @@ function FeedPost({ post }) {
   return (
     <>
       {
-        (modal === true) && (post.author.accountname === MyId) && 
+        (modal === true) &&
         <Modal
           list={list}
           alertTxt={alertTxt}
@@ -115,7 +121,7 @@ function FeedPost({ post }) {
             <IconImg src={isLike ? heartIcon : emptyheartIcon} alt={'좋아요 버튼'} />
             {heartCount}
           </button>
-          <Link to={'/snspostdetail/'+post.id}>
+          <Link to={'/snspostdetail/' + post.id}>
             <button style={{ marginLeft: '6px' }}>
               <IconImg src={messageIcon} alt={'댓글 버튼'} />
               {post.commentCount}

--- a/src/components/postModal/PostModal.jsx
+++ b/src/components/postModal/PostModal.jsx
@@ -7,10 +7,9 @@ export default function Modal({ list, closeModal, alertTxt, setModal }) {
   const [alert, setAlert] = useState(false);
 
   const showAlert = () => {
-    setAlert(alert=>!alert);
-    if (Object.keys(list).find(txt => txt === '신고하기' || txt === '웹사이트에서 상품 보기')) {
-      setAlert(false);
-    }
+    setAlert(alert => !alert);
+    Object.keys(list).find(txt => txt === '웹사이트에서 상품 보기')
+      ? setAlert(false) : setAlert(true)
   };
   const closeAlert = () => {
     setAlert(false);
@@ -35,7 +34,7 @@ export default function Modal({ list, closeModal, alertTxt, setModal }) {
         </ul>
       </ModalWrapper>
       {
-        alert === true && 
+        alert === true &&
         <DeleteAlert
           mainTxt={alertTxt[0]}
           rightBtnTxt={alertTxt[1]}

--- a/src/reducers/reportPostSlice.js
+++ b/src/reducers/reportPostSlice.js
@@ -1,0 +1,58 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const initialState = {
+  type: '',
+  id: '',
+  resMeg: '로딩중',
+  status: 'idle',
+}
+
+export const AxiosReportPost = createAsyncThunk(
+  'reportPost/axiosReportPost',
+  async (URL) => {
+    const token = JSON.parse(localStorage.getItem('token'));
+    const config = {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-type': 'application/json'
+      },
+    }
+    const res = await axios.post(URL, {}, config);
+    return res.data.report;
+  }
+)
+
+export const reportPost = createSlice({
+  name: 'reportPost',
+  initialState,
+  reducers: {
+    selectId(state, action) {
+      state.id = action.payload;
+    },
+    checkType(state, action) {
+      state.type = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(AxiosReportPost.pending, (state) => {
+        state.status = 'loading';
+        state.resMeg = '로드중';
+      })
+      .addCase(AxiosReportPost.fulfilled, (state, action) => {
+        state.status = 'success';
+        state.resMeg = action.payload;
+      })
+      .addCase(AxiosReportPost.rejected, (state) => {
+        state.state = 'fail';
+      });
+  },
+})
+
+export const selectReportMsg = (state) => state.reportPost.resMeg;
+export const getReportStatus = (state) => state.reportPost.status;
+export const ReportId = (state) => state.reportPost.id;
+export const ReportType = (state) => state.reportPost.type;
+export const reportActions = reportPost.actions;
+export default reportPost.reducer;

--- a/src/reducers/reportPostSlice.js
+++ b/src/reducers/reportPostSlice.js
@@ -30,9 +30,6 @@ export const reportPost = createSlice({
     selectId(state, action) {
       state.id = action.payload;
     },
-    checkType(state, action) {
-      state.type = action.payload;
-    },
   },
   extraReducers: (builder) => {
     builder
@@ -52,7 +49,6 @@ export const reportPost = createSlice({
 
 export const selectReportMsg = (state) => state.reportPost.resMeg;
 export const getReportStatus = (state) => state.reportPost.status;
-export const ReportId = (state) => state.reportPost.id;
-export const ReportType = (state) => state.reportPost.type;
+export const reportId = (state) => state.reportPost.id;
 export const reportActions = reportPost.actions;
 export default reportPost.reducer;

--- a/src/template/postDetail/FeedPostDetail.jsx
+++ b/src/template/postDetail/FeedPostDetail.jsx
@@ -49,6 +49,7 @@ export default function FeedPostDetail() {
     alertTxt = ['삭제하시겠어요?', '삭제'];
   } else {
     list = { '신고하기': '' };
+    alertTxt = ['신고하시겠어요?', '신고'];
   }
 
   const closeModal = () => {

--- a/src/template/postDetail/FeedPostDetail.jsx
+++ b/src/template/postDetail/FeedPostDetail.jsx
@@ -7,6 +7,7 @@ import { selectCommentAuthor } from '../../reducers/getCommentSlice'
 import { selectUserData } from '../../reducers/getUserInfoSlice'
 import { AxiosUserData } from '../../reducers/getUserInfoSlice'
 import { selectDetailPosts, AxiosDetail } from '../../reducers/getPostDetailSlice'
+import { deleteActions } from '../../reducers/deletePostSlice';
 import { DetailWrapper } from './FeedPostDetailStyle'
 import { AllWrap, ScrollMain, Heading } from '../../style/commonStyle'
 import Modal from '../../components/postModal/PostModal';
@@ -36,6 +37,7 @@ export default function FeedPostDetail() {
   }, [])
 
   const handleonClick = (postId, postAuthor) => {
+    dispatch(deleteActions.checkType('comments'));
     dispatch(commentAction.selectCommentId(postId));
     dispatch(commentAction.selectCommentAuthor(postAuthor));
     setModal(modal => !modal);


### PR DESCRIPTION
* 게시글 상세페이지에서 댓글의 더보기 버튼(점3개)을 클릭시 신고하기 기능 구현
* 피드페이지와 게시글 상세페이지에서 해당 게시글의 더보기 버튼(점3개)을 클릭하여 신고하기 기능 구현
* 신고하기하면 해당 API에 데이터 전송하고, 신고하기가 완료되었다는 alert창 뜨도록 구현
* 상세페이지에서 내 게시글 삭제 버튼 클릭시 게시글 삭제하고 프로필페이지로 이동하도록 구현

![ddd](https://user-images.githubusercontent.com/97039896/186444007-6a18d98a-a8f4-46d5-84c7-7b69209496da.gif)
![111](https://user-images.githubusercontent.com/97039896/186443030-35606f83-7575-4ba9-a61d-d6a77fe08189.gif)


close #388 #389 